### PR TITLE
Enable gzip compression for faster page loads

### DIFF
--- a/header.php
+++ b/header.php
@@ -1,7 +1,8 @@
 <?php
 
 
-@ini_set('zlib.output_compression_level', 0);
+@ini_set('zlib.output_compression', 1);
+@ini_set('zlib.output_compression_level', 6);
 date_default_timezone_set("Europe/London");
 setlocale(LC_ALL, 'uk_UA.utf8');
 


### PR DESCRIPTION
## Summary
- enable zlib output compression and set compression level to 6 in header

## Testing
- `php -l header.php`

------
https://chatgpt.com/codex/tasks/task_e_68af14a308d4832eaf4215ead2d1fad2