### PR TITLE
refactor: use mysqli consistently

### DIFF
--- a/css/index.php
+++ b/css/index.php
@@ -95,16 +95,13 @@ max(`rawdata`.`abs_pressure`),
 min(`rawdata`.`abs_pressure`),
 max(`rawdata`.`rain`)-min(`rawdata`.`rain`)
 FROM `weather`.`rawdata`WHERE date >= now() - INTERVAL 1 MONTH;";
- $result = mysql_query($SQL);
- if (!$result)
-     {
-     die('Invalid query: ' . mysql_error());
-     }
- while ($row = mysql_fetch_row($result))
-     {
+ $result = mysqli_query($link, $SQL);
+ if (!$result) {
+     die('Invalid query: ' . mysqli_error($link));
+ }
+ while ($row = mysqli_fetch_row($result)) {
 
-     for ($i = 0; $i <= mysql_num_fields($result); $i++)
-         {
+     for ($i = 0; $i <= mysqli_num_fields($result); $i++) {
          $d0  = $row[0];
          $d1  = $row[1];
          $d2  = $row[2];
@@ -733,16 +730,13 @@ $('#dir').highcharts({
 
 ";
 
- $result2 = mysql_query($SQL2);
- if (!$result)
-     {
-     die('Invalid query: ' . mysql_error());
-     }
- while ($row = mysql_fetch_row($result2))
-     {
+ $result2 = mysqli_query($link, $SQL2);
+ if (!$result2) {
+     die('Invalid query: ' . mysqli_error($link));
+ }
+ while ($row = mysqli_fetch_row($result2)) {
 
-     for ($i = 0; $i <= mysql_num_fields($result2); $i++)
-         {
+     for ($i = 0; $i <= mysqli_num_fields($result2); $i++) {
          $d0  = $row[0];
          $d1  = $row[1];
          $d2  = $row[2];
@@ -812,16 +806,13 @@ $('#dir').highcharts({
 				</div>
 ";
 
- $result3 = mysql_query($SQL3);
- if (!$result)
-     {
-     die('Invalid query: ' . mysql_error());
-     }
- while ($row = mysql_fetch_row($result3))
-     {
+ $result3 = mysqli_query($link, $SQL3);
+ if (!$result3) {
+     die('Invalid query: ' . mysqli_error($link));
+ }
+ while ($row = mysqli_fetch_row($result3)) {
 
-     for ($i = 0; $i <= mysql_num_fields($result3); $i++)
-         {
+     for ($i = 0; $i <= mysqli_num_fields($result3); $i++) {
          $d0  = $row[0];
          $d1  = $row[1];
          $d2  = $row[2];
@@ -891,16 +882,13 @@ $('#dir').highcharts({
 				</div>
 ";
 
- $result3 = mysql_query($SQL4);
- if (!$result)
-     {
-     die('Invalid query: ' . mysql_error());
-     }
- while ($row = mysql_fetch_row($result3))
-     {
+ $result4 = mysqli_query($link, $SQL4);
+ if (!$result4) {
+     die('Invalid query: ' . mysqli_error($link));
+ }
+ while ($row = mysqli_fetch_row($result4)) {
 
-     for ($i = 0; $i <= mysql_num_fields($result3); $i++)
-         {
+     for ($i = 0; $i <= mysqli_num_fields($result4); $i++) {
          $d0  = $row[0];
          $d1  = $row[1];
          $d2  = $row[2];
@@ -973,70 +961,58 @@ $('#dir').highcharts({
 
 
 
- $result8 = mysql_query($SQLHOT);
- if (!$result8)
-     {
-     die('Invalid query: ' . mysql_error());
-     }
- while ($row = mysql_fetch_row($result8))
-     {
+ $result8 = mysqli_query($link, $SQLHOT);
+ if (!$result8) {
+     die('Invalid query: ' . mysqli_error($link));
+ }
+ while ($row = mysqli_fetch_row($result8)) {
 
-     for ($i = 0; $i <= mysql_num_fields($result8); $i++)
-         {
+     for ($i = 0; $i <= mysqli_num_fields($result8); $i++) {
          $d0 = $row[0];
          $d1 = $row[1];
-         }
      }
+ }
  echo "<div id=\"billboard\"><h11>Hottest Day of the year  :$d0 &#8451 on the  $d1";
  echo "";
- $result8 = mysql_query($SQLCOLD);
- if (!$result8)
-     {
-     die('Invalid query: ' . mysql_error());
-     }
- while ($row = mysql_fetch_row($result8))
-     {
+ $result8 = mysqli_query($link, $SQLCOLD);
+ if (!$result8) {
+     die('Invalid query: ' . mysqli_error($link));
+ }
+ while ($row = mysqli_fetch_row($result8)) {
 
-     for ($i = 0; $i <= mysql_num_fields($result8); $i++)
-         {
+     for ($i = 0; $i <= mysqli_num_fields($result8); $i++) {
          $d0 = $row[0];
          $d1 = $row[1];
-         }
      }
+ }
  echo "<h11>Coldest Day of the year  :$d0 &#8451 on the  $d1";
  echo "</div>";
 
- $result8 = mysql_query($SQLLONGHOT);
- if (!$result8)
-     {
-     die('Invalid query: ' . mysql_error());
-     }
- while ($row = mysql_fetch_row($result8))
-     {
+ $result8 = mysqli_query($link, $SQLLONGHOT);
+ if (!$result8) {
+     die('Invalid query: ' . mysqli_error($link));
+ }
+ while ($row = mysqli_fetch_row($result8)) {
 
-     for ($i = 0; $i <= mysql_num_fields($result8); $i++)
-         {
+     for ($i = 0; $i <= mysqli_num_fields($result8); $i++) {
          $d0 = $row[0];
-         }
      }
+ }
  echo "<div id=\"billboard\"><h11>Number of Days Over 30&#8451 :$d0 days";
  echo "";
 
 
 
- $result8 = mysql_query($SQLLONGCOLD);
- if (!$result8)
-     {
-     die('Invalid query: ' . mysql_error());
-     }
- while ($row = mysql_fetch_row($result8))
-     {
+ $result8 = mysqli_query($link, $SQLLONGCOLD);
+ if (!$result8) {
+     die('Invalid query: ' . mysqli_error($link));
+ }
+ while ($row = mysqli_fetch_row($result8)) {
 
-     for ($i = 0; $i <= mysql_num_fields($result8); $i++)
-         {
+     for ($i = 0; $i <= mysqli_num_fields($result8); $i++) {
          $d0 = $row[0];
-         }
      }
+ }
  echo "<h11>Number of Days Under 0&#8451  :$d0 days";
  echo "</div>";
 

--- a/getgraphdata.php
+++ b/getgraphdata.php
@@ -19,11 +19,33 @@
 
 if(isset($_GET['item'])){$item = $_GET['item'];}
 
-$allowedItems = ['outTemp','inTemp','outHumidity','inHumidity','windSpeed','windGust','windDir','barometer','pressure','rain','rainRate','rainn','dewpoint','heatindex','windchill','radiation','UV'];
-if (!in_array($item, $allowedItems, true)) {
+// Map of allowed items in lowercase to their canonical column names
+$allowedItems = [
+  'outtemp'     => 'outTemp',
+  'intemp'      => 'inTemp',
+  'outhumidity' => 'outHumidity',
+  'inhumidity'  => 'inHumidity',
+  'windspeed'   => 'windSpeed',
+  'windgust'    => 'windGust',
+  'winddir'     => 'windDir',
+  'barometer'   => 'barometer',
+  'pressure'    => 'pressure',
+  'rain'        => 'rain',
+  'rainrate'    => 'rainRate',
+  'rainn'       => 'rainn',
+  'dewpoint'    => 'dewpoint',
+  'heatindex'   => 'heatindex',
+  'windchill'   => 'windchill',
+  'radiation'   => 'radiation',
+  'uv'          => 'UV'
+];
+
+$itemKey = strtolower($item);
+if (!isset($allowedItems[$itemKey])) {
   http_response_code(400);
   exit('Invalid item parameter');
 }
+$item = $allowedItems[$itemKey];
 
  $callback = $_GET['callback'];
  if (!preg_match('/^[a-zA-Z0-9_]+$/', $callback))
@@ -53,7 +75,7 @@ if (!in_array($item, $allowedItems, true)) {
 // connect to MySQL
 //require_once('../../configuration.php');
 //$conf = new JConfig();
-//mysqli_connect($conf->host, $conf->user, $conf->password) or die(mysql_error());
+//mysqli_connect($conf->host, $conf->user, $conf->password) or die(mysqli_error($link));
 //mysqli_select_db($link,$conf->db) or die(mysqli_error());
  include ('dbconn.php');
 
@@ -104,12 +126,12 @@ if (!in_array($item, $allowedItems, true)) {
      $stmt2 = mysqli_prepare($link, $sql3);
      mysqli_stmt_bind_param($stmt2, 'ss', $startTime, $endTime);
      mysqli_stmt_execute($stmt2);
-     $result2 = mysqli_stmt_get_result($stmt2);
-     $dataRow = mysqli_fetch_row($result2);
-     $data1 = round($dataRow[0], 2);
-     mysqli_free_result($result2);
-     mysqli_stmt_close($stmt2);
- }
+    $result2 = mysqli_stmt_get_result($stmt2);
+    $dataRow = mysqli_fetch_assoc($result2);
+    $data1 = round($dataRow['data'], 2);
+    mysqli_free_result($result2);
+    mysqli_stmt_close($stmt2);
+}
 
 
  if ($item == "rainn")

--- a/multidata.php
+++ b/multidata.php
@@ -15,12 +15,35 @@ date_default_timezone_set("Europe/London");
 // get the parameters
  $start="";
  $end="";
- $item     = $_GET['item'];
- $allowedItems = ['outTemp','inTemp','outHumidity','inHumidity','windSpeed','windGust','windDir','barometer','pressure','rain','rainRate','rainn','dewpoint','heatindex','windchill','radiation','UV'];
- if (!in_array($item, $allowedItems, true)) {
-   http_response_code(400);
-   exit('Invalid item parameter');
- }
+$item     = $_GET['item'];
+
+// Map lowercase inputs to canonical column names
+$allowedItems = [
+  'outtemp'     => 'outTemp',
+  'intemp'      => 'inTemp',
+  'outhumidity' => 'outHumidity',
+  'inhumidity'  => 'inHumidity',
+  'windspeed'   => 'windSpeed',
+  'windgust'    => 'windGust',
+  'winddir'     => 'windDir',
+  'barometer'   => 'barometer',
+  'pressure'    => 'pressure',
+  'rain'        => 'rain',
+  'rainrate'    => 'rainRate',
+  'rainn'       => 'rainn',
+  'dewpoint'    => 'dewpoint',
+  'heatindex'   => 'heatindex',
+  'windchill'   => 'windchill',
+  'radiation'   => 'radiation',
+  'uv'          => 'UV'
+];
+
+$itemKey = strtolower($item);
+if (!isset($allowedItems[$itemKey])) {
+  http_response_code(400);
+  exit('Invalid item parameter');
+}
+$item = $allowedItems[$itemKey];
  $callback = $_GET['callback'];
  if (!preg_match('/^[a-zA-Z0-9_]+$/', $callback))
      {
@@ -48,7 +71,7 @@ date_default_timezone_set("Europe/London");
 // connect to MySQL
 //require_once('../../configuration.php');
 //$conf = new JConfig();
-//mysqli_connect($conf->host, $conf->user, $conf->password) or die(mysql_error());
+//mysqli_connect($conf->host, $conf->user, $conf->password) or die(mysqli_error($link));
 //mysqli_select_db($link,$conf->db) or die(mysqli_error());
 // connect to MySQL
  include ('dbconn.php');
@@ -98,13 +121,13 @@ $result = mysqli_stmt_get_result($stmt);
      $sql3    = "select $item as data from `weather`.`rawdata1d` order by date desc limit 14,1";
      $stmt2 = mysqli_prepare($link, $sql3);
      mysqli_stmt_execute($stmt2);
-     $result2 = mysqli_stmt_get_result($stmt2);
+    $result2 = mysqli_stmt_get_result($stmt2);
 
-     $row2 = mysqli_fetch_row($result2);
-     $data1 = round($row2[0], 2);
-     mysqli_free_result($result2);
-     mysqli_stmt_close($stmt2);
-     }
+    $row2 = mysqli_fetch_assoc($result2);
+    $data1 = round($row2['data'], 2);
+    mysqli_free_result($result2);
+    mysqli_stmt_close($stmt2);
+    }
 
 
  if ($item == "rainn")


### PR DESCRIPTION
## Summary
- replace legacy `mysql_*` calls in `css/index.php` with `mysqli`
- use `mysqli_fetch_assoc` for single-value queries in data endpoints
- accept lowercase item parameters in API endpoints so graphs load correctly

## Testing
- `php -l css/index.php`
- `php -l getgraphdata.php`
- `php -l multidata.php`


------
https://chatgpt.com/codex/tasks/task_e_68af181ee378832ebe7c0307a958094c