### PR TITLE
Wrap page content in card container

### DIFF
--- a/header.php
+++ b/header.php
@@ -96,4 +96,4 @@ $minTemp = $row['minTemp'];
           document.getElementById('sidebar').classList.toggle('-translate-x-full');
         });
       </script>
-      <div class="flex-1 p-4">
+      <div class="flex-1 p-4 bg-white shadow rounded">


### PR DESCRIPTION
## Summary
- Style main content container as a card to ensure all pages place their elements within a consistent card layout.

## Testing
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_68af24610280832e86b2062a185799a5