### PR TITLE
Use full-width layout for dashboard

### DIFF
--- a/header.php
+++ b/header.php
@@ -93,5 +93,5 @@ $minTemp = $row['minTemp'];
         document.getElementById('sidebar').classList.toggle('-translate-x-full');
       });
     </script>
-    <div class="flex-1 flex flex-col md:ml-64">
+    <div class="flex-1 flex flex-col">
       <div class="flex-1 p-4">

--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@ include('dbconn.php');
 ?>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/paho-mqtt/1.0.1/mqttws31.js" type="text/javascript"></script>
 
-<div class="max-w-screen-xl mx-auto p-4">
+<div>
   <div class="flex flex-col sm:flex-row items-center justify-between mb-2">
     <h1 class="text-2xl text-gray-800">Current Conditions</h1>
   </div>
@@ -132,7 +132,7 @@ include('dbconn.php');
   </div>
 </div>
 
-<div class="max-w-screen-xl mx-auto p-4">
+<div>
   <div class="flex justify-center">
     <div class="w-full md:w-1/2 xl:w-1/3">
       <div class="bg-white shadow rounded p-4">


### PR DESCRIPTION
## Summary
- Remove extra left margin to align content flush with the sidebar.
- Drop fixed max-width wrappers so dashboard cards expand across full available space.

## Testing
- `php -l header.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68af290b7a54832e8640923fea3c9ef0