### PR TITLE
Use CDN-hosted Highcharts

### DIFF
--- a/css/index.php
+++ b/css/index.php
@@ -133,10 +133,6 @@ FROM `weather`.`rawdata`WHERE date >= now() - INTERVAL 1 MONTH;";
  $ss   = date_sunset(time(), SUNFUNCS_RET_STRING, 51.752646, -0.325041, 90, 0);
  $sr   = date_sunrise(time(), SUNFUNCS_RET_STRING, 51.752646, -0.325041, 90, 0);
  ?>
-<script type='text/javascript' src='../frontend/js/jquery.min.js'></script>
-<script src="http://code.highcharts.com/stock/highstock.js"></script>
-<script src="http://code.highcharts.com/highcharts-more.js"></script>
-<script src="http://code.highcharts.com/modules/solid-gauge.src.js"></script>
 <script type="text/javascript">
 $(function () {
 Highcharts.setOptions({


### PR DESCRIPTION
## Summary
- Remove hardcoded Highcharts scripts from `css/index.php` to rely on CDN-loaded copies.
- Site now uses the up-to-date Highcharts modules already referenced in `header.php`.

## Testing
- `php -l css/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68af35687998832e89e42a121ef3eb27