### PR TITLE
Add data tables to extremes page

### DIFF
--- a/extremes.php
+++ b/extremes.php
@@ -35,19 +35,88 @@ $month = fetchStats($link, '1 MONTH');
   <div class="d-sm-flex align-items-center justify-content-between mb-2">
     <h1 class="h3 mb-0 text-gray-800">Extremes</h1>
   </div>
+
   <div class="card shadow mb-3">
+    <div class="card-header">
+      <h2 class="h5 mb-0">Last 24 Hours</h2>
+    </div>
     <div class="card-body">
-      <div id="dayChart" style="height: 400px"></div>
+      <div class="row">
+        <div class="col-md-6">
+          <div id="dayChart" style="height: 400px"></div>
+        </div>
+        <div class="col-md-6">
+          <table class="table table-sm">
+            <thead>
+              <tr><th>Metric</th><th>Max</th><th>Min</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Outside Temp</td><td><?php echo $day['outTempMax']; ?></td><td><?php echo $day['outTempMin']; ?></td></tr>
+              <tr><td>Inside Temp</td><td><?php echo $day['inTempMax']; ?></td><td><?php echo $day['inTempMin']; ?></td></tr>
+              <tr><td>Inside Humidity</td><td><?php echo $day['inHumMax']; ?></td><td><?php echo $day['inHumMin']; ?></td></tr>
+              <tr><td>Outside Humidity</td><td><?php echo $day['outHumMax']; ?></td><td><?php echo $day['outHumMin']; ?></td></tr>
+              <tr><td>Pressure</td><td><?php echo $day['baroMax']; ?></td><td><?php echo $day['baroMin']; ?></td></tr>
+              <tr><td>Rain (total)</td><td><?php echo $day['rainTotal']; ?></td><td>0</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
+
   <div class="card shadow mb-3">
+    <div class="card-header">
+      <h2 class="h5 mb-0">Last 7 Days</h2>
+    </div>
     <div class="card-body">
-      <div id="weekChart" style="height: 400px"></div>
+      <div class="row">
+        <div class="col-md-6">
+          <div id="weekChart" style="height: 400px"></div>
+        </div>
+        <div class="col-md-6">
+          <table class="table table-sm">
+            <thead>
+              <tr><th>Metric</th><th>Max</th><th>Min</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Outside Temp</td><td><?php echo $week['outTempMax']; ?></td><td><?php echo $week['outTempMin']; ?></td></tr>
+              <tr><td>Inside Temp</td><td><?php echo $week['inTempMax']; ?></td><td><?php echo $week['inTempMin']; ?></td></tr>
+              <tr><td>Inside Humidity</td><td><?php echo $week['inHumMax']; ?></td><td><?php echo $week['inHumMin']; ?></td></tr>
+              <tr><td>Outside Humidity</td><td><?php echo $week['outHumMax']; ?></td><td><?php echo $week['outHumMin']; ?></td></tr>
+              <tr><td>Pressure</td><td><?php echo $week['baroMax']; ?></td><td><?php echo $week['baroMin']; ?></td></tr>
+              <tr><td>Rain (total)</td><td><?php echo $week['rainTotal']; ?></td><td>0</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
+
   <div class="card shadow mb-3">
+    <div class="card-header">
+      <h2 class="h5 mb-0">Last Month</h2>
+    </div>
     <div class="card-body">
-      <div id="monthChart" style="height: 400px"></div>
+      <div class="row">
+        <div class="col-md-6">
+          <div id="monthChart" style="height: 400px"></div>
+        </div>
+        <div class="col-md-6">
+          <table class="table table-sm">
+            <thead>
+              <tr><th>Metric</th><th>Max</th><th>Min</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Outside Temp</td><td><?php echo $month['outTempMax']; ?></td><td><?php echo $month['outTempMin']; ?></td></tr>
+              <tr><td>Inside Temp</td><td><?php echo $month['inTempMax']; ?></td><td><?php echo $month['inTempMin']; ?></td></tr>
+              <tr><td>Inside Humidity</td><td><?php echo $month['inHumMax']; ?></td><td><?php echo $month['inHumMin']; ?></td></tr>
+              <tr><td>Outside Humidity</td><td><?php echo $month['outHumMax']; ?></td><td><?php echo $month['outHumMin']; ?></td></tr>
+              <tr><td>Pressure</td><td><?php echo $month['baroMax']; ?></td><td><?php echo $month['baroMin']; ?></td></tr>
+              <tr><td>Rain (total)</td><td><?php echo $month['rainTotal']; ?></td><td>0</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Display separate sections for day, week, and month extremes
- Show data tables beside each chart for clearer comparison

## Testing
- `php -l extremes.php`


------
https://chatgpt.com/codex/tasks/task_e_68af35e7ac74832eb391f78a8d17244d