### PR TITLE
Centralize database queries

### DIFF
--- a/cleandata.php
+++ b/cleandata.php
@@ -13,13 +13,13 @@
 //$sql5="delete FROM weather.rawdata where temp_out = 32.7;";
 
  include ('dbconn.php');
- $result = mysqli_query($link,$sql0);
- $result = mysqli_query($link,$sql1);
- $result = mysqli_query($link,$sql2);
- $result = mysqli_query($link,$sql3);
- $result = mysqli_query($link,$sql4);
- $result = mysqli_query($link,$sql5);
-$result = mysqli_query($link,$sql6);
-$result = mysqli_query($link,$sql7);
+ db_query($sql0);
+ db_query($sql1);
+ db_query($sql2);
+ db_query($sql3);
+ db_query($sql4);
+ db_query($sql5);
+ db_query($sql6);
+ db_query($sql7);
  echo "All done.";
 ?>

--- a/css/index.php
+++ b/css/index.php
@@ -95,10 +95,7 @@ max(`rawdata`.`abs_pressure`),
 min(`rawdata`.`abs_pressure`),
 max(`rawdata`.`rain`)-min(`rawdata`.`rain`)
 FROM `weather`.`rawdata`WHERE date >= now() - INTERVAL 1 MONTH;";
- $result = mysqli_query($link, $SQL);
- if (!$result) {
-     die('Invalid query: ' . mysqli_error($link));
- }
+ $result = db_query($SQL);
  while ($row = mysqli_fetch_row($result)) {
 
      for ($i = 0; $i <= mysqli_num_fields($result); $i++) {
@@ -726,10 +723,7 @@ Highcharts.chart('dir', {
 
 ";
 
- $result2 = mysqli_query($link, $SQL2);
- if (!$result2) {
-     die('Invalid query: ' . mysqli_error($link));
- }
+ $result2 = db_query($SQL2);
  while ($row = mysqli_fetch_row($result2)) {
 
      for ($i = 0; $i <= mysqli_num_fields($result2); $i++) {
@@ -802,10 +796,7 @@ Highcharts.chart('dir', {
 				</div>
 ";
 
- $result3 = mysqli_query($link, $SQL3);
- if (!$result3) {
-     die('Invalid query: ' . mysqli_error($link));
- }
+ $result3 = db_query($SQL3);
  while ($row = mysqli_fetch_row($result3)) {
 
      for ($i = 0; $i <= mysqli_num_fields($result3); $i++) {
@@ -878,10 +869,7 @@ Highcharts.chart('dir', {
 				</div>
 ";
 
- $result4 = mysqli_query($link, $SQL4);
- if (!$result4) {
-     die('Invalid query: ' . mysqli_error($link));
- }
+ $result4 = db_query($SQL4);
  while ($row = mysqli_fetch_row($result4)) {
 
      for ($i = 0; $i <= mysqli_num_fields($result4); $i++) {
@@ -957,10 +945,7 @@ Highcharts.chart('dir', {
 
 
 
- $result8 = mysqli_query($link, $SQLHOT);
- if (!$result8) {
-     die('Invalid query: ' . mysqli_error($link));
- }
+ $result8 = db_query($SQLHOT);
  while ($row = mysqli_fetch_row($result8)) {
 
      for ($i = 0; $i <= mysqli_num_fields($result8); $i++) {
@@ -970,10 +955,7 @@ Highcharts.chart('dir', {
  }
  echo "<div id=\"billboard\"><h11>Hottest Day of the year  :$d0 &#8451 on the  $d1";
  echo "";
- $result8 = mysqli_query($link, $SQLCOLD);
- if (!$result8) {
-     die('Invalid query: ' . mysqli_error($link));
- }
+ $result8 = db_query($SQLCOLD);
  while ($row = mysqli_fetch_row($result8)) {
 
      for ($i = 0; $i <= mysqli_num_fields($result8); $i++) {
@@ -984,10 +966,7 @@ Highcharts.chart('dir', {
  echo "<h11>Coldest Day of the year  :$d0 &#8451 on the  $d1";
  echo "</div>";
 
- $result8 = mysqli_query($link, $SQLLONGHOT);
- if (!$result8) {
-     die('Invalid query: ' . mysqli_error($link));
- }
+ $result8 = db_query($SQLLONGHOT);
  while ($row = mysqli_fetch_row($result8)) {
 
      for ($i = 0; $i <= mysqli_num_fields($result8); $i++) {
@@ -999,10 +978,7 @@ Highcharts.chart('dir', {
 
 
 
- $result8 = mysqli_query($link, $SQLLONGCOLD);
- if (!$result8) {
-     die('Invalid query: ' . mysqli_error($link));
- }
+ $result8 = db_query($SQLLONGCOLD);
  while ($row = mysqli_fetch_row($result8)) {
 
      for ($i = 0; $i <= mysqli_num_fields($result8); $i++) {

--- a/dbconn.php
+++ b/dbconn.php
@@ -13,4 +13,23 @@ $link = mysqli_connect($db_host, $db_user, $db_pass, $db_name);
 if (! $link) {
   die('Connect Error (' . mysqli_connect_errno() . '): ' . mysqli_connect_error());
 }
+
+/**
+ * Execute a SQL query using the shared connection.
+ *
+ * @param string $sql      The SQL statement to run.
+ * @param mysqli|null $conn Optional connection; defaults to global link.
+ *
+ * @return mysqli_result
+ */
+function db_query(string $sql, $conn = null)
+{
+  global $link;
+  $handle = $conn ?: $link;
+  $result = mysqli_query($handle, $sql);
+  if (! $result) {
+    die('Query Error: ' . mysqli_error($handle) . ' SQL: ' . $sql);
+  }
+  return $result;
+}
 ?>

--- a/extremes.php
+++ b/extremes.php
@@ -2,7 +2,7 @@
 include('header.php');
 include('dbconn.php');
 
-function fetchStats($link, $interval) {
+ function fetchStats($interval) {
   $sql = "SELECT round(max(archive.outTemp),1) as outTempMax,
                  round(min(archive.outTemp),1) as outTempMin,
                  round(max(archive.inTemp),1) as inTempMax,
@@ -16,18 +16,15 @@ function fetchStats($link, $interval) {
                  round(max(archive.rain)-min(archive.rain),1) as rainTotal
           FROM weewx.archive
           WHERE from_unixtime(dateTime) >= now() - INTERVAL $interval;";
-  $result = mysqli_query($link, $sql);
-  if (! $result) {
-    die('Invalid query: ' . mysqli_error($link));
-  }
+    $result = db_query($sql);
   $row = mysqli_fetch_assoc($result);
   mysqli_free_result($result);
   return $row;
 }
 
-$day = fetchStats($link, '1 DAY');
-$week = fetchStats($link, '7 DAY');
-$month = fetchStats($link, '1 MONTH');
+ $day = fetchStats('1 DAY');
+ $week = fetchStats('7 DAY');
+ $month = fetchStats('1 MONTH');
 ?>
 </head>
 

--- a/getdata.php
+++ b/getdata.php
@@ -28,35 +28,15 @@ $SQLd = " ON DUPLICATE KEY UPDATE date = date";
 $SQL = $SQLa . join(',', $values) . $SQLd;
 
 // Connect to the local database
-$link = mysqli_connect('localhost', 'root', '92987974');
-if (! $link) {
-  die('Not connected : ' . mysqli_connect_error());
-}
-
-$db_selected = mysqli_select_db($link, 'weather');
-if (! $db_selected) {
-  die('Can\'t use db : ' . mysqli_error($link));
-}
-
-$result = mysqli_query($link, $SQL);
-if (! $result) {
-  die('<div id=\"billboard\"> <p>Invalid query: ' . mysqli_error($link) . '</p></div>');
-}
+include('dbconn.php');
+db_query($SQL);
 
 // Replicate to a remote database
-$link2 = mysqli_connect('accounts.smeird.com', 'root', '92987974');
+$link2 = mysqli_connect('accounts.smeird.com', 'root', '92987974', 'weather');
 if (! $link2) {
   die('Not connected : ' . mysqli_connect_error());
 }
 
-$db_selected = mysqli_select_db($link2, 'weather');
-if (! $db_selected) {
-  die('Can\'t use db : ' . mysqli_error($link2));
-}
-
-$result = mysqli_query($link2, $SQL);
-if (! $result) {
-  die('<div id=\"billboard\"> <p>Invalid query: ' . mysqli_error($link2) . '</p></div>');
-}
+db_query($SQL, $link2);
 ?>
 

--- a/getgraphdata.php
+++ b/getgraphdata.php
@@ -80,7 +80,7 @@ $item = $allowedItems[$itemKey];
  include ('dbconn.php');
 
 // set UTC time
- //mysqli_query($link,"SET time_zone = '+00:00'");
+//db_query("SET time_zone = '+00:00'");
 
 // set some utility variables
  $range     = $end - $start;

--- a/getgraphdata2.php
+++ b/getgraphdata2.php
@@ -46,7 +46,7 @@ $max      = $itemmm;
  include ('dbconn.php');
 
 // set UTC time
- //mysqli_query($link,"SET time_zone = '+00:00'");
+//db_query("SET time_zone = '+00:00'");
 
 // set some utility variables
  $range     = $end - $start;

--- a/header.php
+++ b/header.php
@@ -16,7 +16,7 @@ $sql = "
         `archive`.`dateTime` DESC
     LIMIT 1;
 ";
-$result = mysqli_query($link,$sql) or die(mysqli_connect_error());
+ $result = db_query($sql);
 
 // Fetch the result row as an associative array
 $row = mysqli_fetch_assoc($result);

--- a/iphone.php
+++ b/iphone.php
@@ -43,13 +43,9 @@
 FROM `weather`.`rawdata`
 order by date desc limit 1
 ;";
-         $result = mysqli_query($link,$SQL);
-         if (!$result)
-             {
-             die('Invalid query: ' . mysqli_error());
-             }
-         while ($row = mysqli_fetch_row($result))
-             {
+        $result = db_query($SQL);
+        while ($row = mysqli_fetch_row($result))
+            {
 
              for ($i = 0; $i <= mysqli_num_fields($result); $i++)
                  {
@@ -155,13 +151,9 @@ max(`rawdata`.`abs_pressure`),
 min(`rawdata`.`abs_pressure`),
 max(`rawdata`.`rain`)-min(`rawdata`.`rain`)
 FROM `weather`.`rawdata`WHERE date >= now() - INTERVAL 1 DAY;";
-         $result = mysqli_query($link,$SQL2);
-         if (!$result)
-             {
-             die('Invalid query: ' . mysqli_error());
-             }
-         while ($row = mysqli_fetch_row($result))
-             {
+        $result = db_query($SQL2);
+        while ($row = mysqli_fetch_row($result))
+            {
 
              for ($i = 0; $i <= mysqli_num_fields($result); $i++)
                  {
@@ -241,13 +233,9 @@ max(`rawdata`.`abs_pressure`),
 min(`rawdata`.`abs_pressure`),
 max(`rawdata`.`rain`)-min(`rawdata`.`rain`)
 FROM `weather`.`rawdata`WHERE date >= now() - INTERVAL 7 DAY;";
-         $result = mysqli_query($link,$SQL3);
-         if (!$result)
-             {
-             die('Invalid query: ' . mysqli_error());
-             }
-         while ($row = mysqli_fetch_row($result))
-             {
+        $result = db_query($SQL3);
+        while ($row = mysqli_fetch_row($result))
+            {
 
              for ($i = 0; $i <= mysqli_num_fields($result); $i++)
                  {
@@ -327,13 +315,9 @@ max(`rawdata`.`abs_pressure`),
 min(`rawdata`.`abs_pressure`),
 max(`rawdata`.`rain`)-min(`rawdata`.`rain`)
 FROM `weather`.`rawdata`WHERE date >= now() - INTERVAL 1 MONTH;";
-         $result = mysqli_query($link,$SQL4);
-         if (!$result)
-             {
-             die('Invalid query: ' . mysqli_error());
-             }
-         while ($row = mysqli_fetch_row($result))
-             {
+        $result = db_query($SQL4);
+        while ($row = mysqli_fetch_row($result))
+            {
 
              for ($i = 0; $i <= mysqli_num_fields($result); $i++)
                  {

--- a/maxmin.php
+++ b/maxmin.php
@@ -2,23 +2,20 @@
 include('header.php');
 include('dbconn.php');
 
-function fetchStats($link, $sql) {
-  $result = mysqli_query($link, $sql);
-  if (! $result) {
-    die('Invalid query: ' . mysqli_error($link));
-  }
-  $row = mysqli_fetch_row($result);
-  mysqli_free_result($result);
-  return $row;
+ function fetchStats($sql) {
+   $result = db_query($sql);
+   $row = mysqli_fetch_row($result);
+   mysqli_free_result($result);
+   return $row;
 }
 
 $daySql = "SELECT round(max(`archive`.`outTemp`), 1), round(min(`archive`.`outTemp`), 1), round(max(`archive`.`inTemp`), 1), round(min(`archive`.`inTemp`), 1), round(max(`archive`.`inHumidity`), 1), round(min(`archive`.`inHumidity`), 1), round(max(`archive`.`outHumidity`), 1), round(min(`archive`.`outHumidity`), 1), round(max(`archive`.`barometer`), 1), round(min(`archive`.`barometer`), 1), round(max(`archive`.`rain`)-min(`archive`.`rain`), 1) FROM `weewx`.`archive` WHERE from_unixtime(dateTime) >= now() - INTERVAL 1 DAY;";
 $weekSql = "SELECT round(max(`archive`.`outTemp`), 1), round(min(`archive`.`outTemp`), 1), round(max(`archive`.`inTemp`), 1), round(min(`archive`.`inTemp`), 1), round(max(`archive`.`inHumidity`), 1), round(min(`archive`.`inHumidity`), 1), round(max(`archive`.`outHumidity`), 1), round(min(`archive`.`outHumidity`), 1), round(max(`archive`.`barometer`), 1), round(min(`archive`.`barometer`), 1), round(max(`archive`.`rain`)-min(`archive`.`rain`), 1) FROM `weewx`.`archive` WHERE from_unixtime(dateTime) >= now() - INTERVAL 7 DAY;";
 $monthSql = "SELECT round(max(`archive`.`outTemp`), 1), round(min(`archive`.`outTemp`), 1), round(max(`archive`.`inTemp`), 1), round(min(`archive`.`inTemp`), 1), round(max(`archive`.`inHumidity`), 1), round(min(`archive`.`inHumidity`), 1), round(max(`archive`.`outHumidity`), 1), round(min(`archive`.`outHumidity`), 1), round(max(`archive`.`barometer`), 1), round(min(`archive`.`barometer`), 1), round(max(`archive`.`rain`)-min(`archive`.`rain`), 1) FROM `weewx`.`archive` WHERE from_unixtime(dateTime) >= now() - INTERVAL 1 MONTH;";
 
-$day = fetchStats($link, $daySql);
-$week = fetchStats($link, $weekSql);
-$month = fetchStats($link, $monthSql);
+ $day = fetchStats($daySql);
+ $week = fetchStats($weekSql);
+ $month = fetchStats($monthSql);
 ?>
 </head>
 

--- a/multidata.php
+++ b/multidata.php
@@ -77,7 +77,7 @@ $item = $allowedItems[$itemKey];
  include ('dbconn.php');
 
 // set UTC time
- mysqli_query($link,"SET time_zone = '+00:00'");
+db_query("SET time_zone = '+00:00'");
 
 // set some utility variables
  $range     = $end - $start;

--- a/records.php
+++ b/records.php
@@ -32,33 +32,21 @@ FROM
 WHERE
  `archive`.`outTemp` < -5;";
 
-$resultHot = mysqli_query($link, $SQLHOT);
-if (! $resultHot) {
-  die('Invalid query: ' . mysqli_error($link) . $SQLHOT);
-}
-$hot = mysqli_fetch_row($resultHot);
-mysqli_free_result($resultHot);
+ $resultHot = db_query($SQLHOT);
+ $hot = mysqli_fetch_row($resultHot);
+ mysqli_free_result($resultHot);
 
-$resultCold = mysqli_query($link, $SQLCOLD);
-if (! $resultCold) {
-  die('Invalid query: ' . mysqli_error($link));
-}
-$cold = mysqli_fetch_row($resultCold);
-mysqli_free_result($resultCold);
+ $resultCold = db_query($SQLCOLD);
+ $cold = mysqli_fetch_row($resultCold);
+ mysqli_free_result($resultCold);
 
-$resultLongHot = mysqli_query($link, $SQLLONGHOT);
-if (! $resultLongHot) {
-  die('Invalid query: ' . mysqli_error($link));
-}
-$daysOver35 = mysqli_fetch_row($resultLongHot)[0];
-mysqli_free_result($resultLongHot);
+ $resultLongHot = db_query($SQLLONGHOT);
+ $daysOver35 = mysqli_fetch_row($resultLongHot)[0];
+ mysqli_free_result($resultLongHot);
 
-$resultLongCold = mysqli_query($link, $SQLLONGCOLD);
-if (! $resultLongCold) {
-  die('Invalid query: ' . mysqli_error($link));
-}
-$daysUnderMinus5 = mysqli_fetch_row($resultLongCold)[0];
-mysqli_free_result($resultLongCold);
+ $resultLongCold = db_query($SQLLONGCOLD);
+ $daysUnderMinus5 = mysqli_fetch_row($resultLongCold)[0];
+ mysqli_free_result($resultLongCold);
 ?>
 </head>
 

--- a/report.php
+++ b/report.php
@@ -49,11 +49,7 @@ GROUP BY d.year, d.month
 ORDER BY d.year, d.month;
 ";
 
-$result = mysqli_query($link, $sql);
-
-if (!$result) {
-    die('Invalid query: ' . mysqli_error($link));
-}
+ $result = db_query($sql);
 
 // Initialize arrays to hold monthly data and totals
 $monthly_data = array();

--- a/reportrainyeartotals.php
+++ b/reportrainyeartotals.php
@@ -22,11 +22,7 @@ GROUP BY year, month
 ORDER BY year, month;
 ";
 
-$result = mysqli_query($link, $sql);
-
-if (!$result) {
-    die('Invalid query: ' . mysqli_error($link));
-}
+ $result = db_query($sql);
 
 // Initialize arrays to hold the data
 $rainfall_data = array();

--- a/reporttempyeartotals.php
+++ b/reporttempyeartotals.php
@@ -21,11 +21,7 @@ GROUP BY year, month
 ORDER BY year, month;
 ";
 
-$result = mysqli_query($link, $sql);
-
-if (!$result) {
-  die('Invalid query: ' . mysqli_error($link));
-}
+ $result = db_query($sql);
 
 // Initialize arrays to hold the data
 $temperature_data = array();

--- a/reportwindyeartotals.php
+++ b/reportwindyeartotals.php
@@ -27,11 +27,7 @@ FROM (
 ORDER BY t.year, t.month;
 ";
 
-$result = mysqli_query($link, $sql);
-
-if (!$result) {
-    die('Invalid query: ' . mysqli_error($link));
-}
+ $result = db_query($sql);
 
 // Initialize arrays to hold the data
 $wind_data = array();

--- a/schedual.php
+++ b/schedual.php
@@ -1,20 +1,20 @@
 <?php
 // connect to MySQL
  include ('dbconn.php');
-mysqli_query($link,'call clean_raw;') or die(mysqli_error());
+ db_query('call clean_raw;');
 echo "Cleaned";
 flush();
-mysqli_query($link,'call weather.fill_cubes_1d();') or die(mysqli_error());
+ db_query('call weather.fill_cubes_1d();');
 echo "..6..";
-mysqli_query($link,'call weather.fill_cubes_1h();') or die(mysqli_error());
+ db_query('call weather.fill_cubes_1h();');
 echo "..5..";
-mysqli_query($link,'call weather.fill_cubes_1d();') or die(mysqli_error());
+ db_query('call weather.fill_cubes_1d();');
 echo "..4..";
-mysqli_query($link,'call weather.fill_cubes_min_max_1d();') or die(mysqli_error());
+ db_query('call weather.fill_cubes_min_max_1d();');
 echo "..3..";
-mysqli_query($link,'call weather.fill_cubes_min_max_1h();') or die(mysqli_error());
+ db_query('call weather.fill_cubes_min_max_1h();');
 echo "..2..";
-mysqli_query($link,'call weather.fill_cubes_min_max_1m();') or die(mysqli_error());
+ db_query('call weather.fill_cubes_min_max_1m();');
 
-echo "Done";
-?>
+ echo "Done";
+ ?>

--- a/winddata.php
+++ b/winddata.php
@@ -10,8 +10,8 @@ $sql = "SELECT wind_dir,
   FROM rawdata
   GROUP BY wind_dir";
 
-include('dbconn.php');
-$result = mysqli_query($link, $sql) or die(mysqli_error($link));
+ include('dbconn.php');
+ $result = db_query($sql);
 
 $rows = array();
 while ($row = mysqli_fetch_assoc($result)) {

--- a/windrose.php
+++ b/windrose.php
@@ -125,7 +125,7 @@ group by wind_dir";
      $sql = $sql1;
      }
  include ('dbconn.php');
- $result = mysqli_query($link,$sql) or die(mysqli_error());
+ $result = db_query($sql);
  echo "</div><div class=\"overflow-x-auto mb-3\">
  <table id=\"freqq\" class=\"min-w-full divide-y divide-gray-200 text-sm\">";
  echo "<thead class=\"bg-gray-50\"><tr>
@@ -221,11 +221,8 @@ group by wind_dir";
          include ('dbconn.php');
          //connect to a db
 $title="Select date";
-         $resultg = mysqli_query($link,$SQL);
-         if (!$resultg)
-             {
-             die('Invalid query: ' . mysqli_error());
-             } $html = "<select class=input-form style=\"width: 200px\" title=\"$title\" name=\"$name\">";
+        $resultg = db_query($SQL);
+        $html = "<select class=input-form style=\"width: 200px\" title=\"$title\" name=\"$name\">";
          while ($row  = mysqli_fetch_row($resultg))
              {
              for ($i = 0; $i <= mysqli_num_fields($resultg); $i++)


### PR DESCRIPTION
## Summary
- add `db_query` helper to standardize MySQL requests
- refactor ingestion and reporting scripts to use the shared helper

## Testing
- `for f in dbconn.php cleandata.php css/index.php schedual.php records.php multidata.php windrose.php winddata.php getgraphdata2.php report.php header.php reporttempyeartotals.php extremes.php getgraphdata.php reportrainyeartotals.php reportwindyeartotals.php maxmin.php iphone.php getdata.php; do php -l $f; done`


------
https://chatgpt.com/codex/tasks/task_e_68af3905646c832eb73b53b005b58bcd