### PR TITLE
Avoid duplicate database connection includes

### DIFF
--- a/cleandata.php
+++ b/cleandata.php
@@ -12,7 +12,7 @@
  $sql7 = "delete from rawdata1m where temp_out < -100;";
 //$sql5="delete FROM weather.rawdata where temp_out = 32.7;";
 
- include ('dbconn.php');
+ require_once 'dbconn.php';
  db_query($sql0);
  db_query($sql1);
  db_query($sql2);

--- a/css/index.php
+++ b/css/index.php
@@ -20,7 +20,7 @@
 
 
  include ('header.php');
- include ('dbconn.php');
+ require_once 'dbconn.php';
  $item   = isset($_GET['item']) ? $_GET['item'] : null;
  $itemmm = isset($_GET['itemmm']) ? $_GET['itemmm'] : null;
  $allowed = ['temp_out','temp_in','hum_in','hum_out','abs_pressure','wind_ave','wind_gust','wind_dir','rain'];

--- a/extremes.php
+++ b/extremes.php
@@ -1,6 +1,6 @@
 <?php
 include('header.php');
-include('dbconn.php');
+require_once 'dbconn.php';
 
  function fetchStats($interval) {
   $sql = "SELECT round(max(archive.outTemp),1) as outTempMax,

--- a/getdata.php
+++ b/getdata.php
@@ -28,7 +28,7 @@ $SQLd = " ON DUPLICATE KEY UPDATE date = date";
 $SQL = $SQLa . join(',', $values) . $SQLd;
 
 // Connect to the local database
-include('dbconn.php');
+require_once 'dbconn.php';
 db_query($SQL);
 
 // Replicate to a remote database

--- a/getgraphdata.php
+++ b/getgraphdata.php
@@ -77,7 +77,7 @@ $item = $allowedItems[$itemKey];
 //$conf = new JConfig();
 //mysqli_connect($conf->host, $conf->user, $conf->password) or die(mysqli_error($link));
 //mysqli_select_db($link,$conf->db) or die(mysqli_error());
- include ('dbconn.php');
+ require_once 'dbconn.php';
 
 // set UTC time
 //db_query("SET time_zone = '+00:00'");

--- a/getgraphdata2.php
+++ b/getgraphdata2.php
@@ -43,7 +43,7 @@ $max      = $itemmm;
 
 
 // connect to MySQL
- include ('dbconn.php');
+ require_once 'dbconn.php';
 
 // set UTC time
 //db_query("SET time_zone = '+00:00'");

--- a/graph.php
+++ b/graph.php
@@ -5,7 +5,7 @@
    http_response_code(400);
    exit('Invalid item parameter');
  }
- include ('dbconn.php');
+ require_once 'dbconn.php';
 
  if ($item == "wind_ave")
      {

--- a/header.php
+++ b/header.php
@@ -4,7 +4,7 @@
 date_default_timezone_set("Europe/London");
 setlocale(LC_ALL, 'uk_UA.utf8');
 
-include('dbconn.php');
+require_once 'dbconn.php';
 $sql = "
     SELECT
         round(`archive`.`outTemp`,2) AS `outTemp`,

--- a/index.php
+++ b/index.php
@@ -1,7 +1,7 @@
 <?php
 // Load shared page components and database connection
 include('header.php');
-include('dbconn.php');
+require_once 'dbconn.php';
 ?>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/paho-mqtt/1.0.1/mqttws31.js" type="text/javascript"></script>
 

--- a/iphone.php
+++ b/iphone.php
@@ -26,7 +26,7 @@
 
 
         <?php
-         include ('dbconn.php');
+         require_once 'dbconn.php';
 
          $SQL    = "SELECT
 `rawdata`.`ID`,

--- a/maxmin.php
+++ b/maxmin.php
@@ -1,6 +1,6 @@
 <?php
 include('header.php');
-include('dbconn.php');
+require_once 'dbconn.php';
 
  function fetchStats($sql) {
    $result = db_query($sql);

--- a/multidata.php
+++ b/multidata.php
@@ -74,7 +74,7 @@ $item = $allowedItems[$itemKey];
 //mysqli_connect($conf->host, $conf->user, $conf->password) or die(mysqli_error($link));
 //mysqli_select_db($link,$conf->db) or die(mysqli_error());
 // connect to MySQL
- include ('dbconn.php');
+ require_once 'dbconn.php';
 
 // set UTC time
 db_query("SET time_zone = '+00:00'");

--- a/newgraph.php
+++ b/newgraph.php
@@ -1,6 +1,6 @@
 <?php
 include('header.php');
-include('dbconn.php');
+require_once 'dbconn.php';
 $allowedWhat = ['rain','inTemp','outTemp','barometer','outHumidity','inHumidity','windSpeed','windGust','windDir','windGustDir'];
 $allowedScale = ['hour','day','48','week','month','qtr','6m','year','all'];
 $allowedType = ['MINMAX','STANDARD'];

--- a/records.php
+++ b/records.php
@@ -1,6 +1,6 @@
 <?php
 include('header.php');
-include('dbconn.php');
+require_once 'dbconn.php';
 
 $SQLHOT = "SELECT
  ROUND(`archive`.`outTemp`, 1) AS 'Max Temperature',

--- a/report.php
+++ b/report.php
@@ -1,6 +1,6 @@
 <?php
 include('header.php');
-include('dbconn.php');
+require_once 'dbconn.php';
 
 echo "<div class=\"container\">
     <h2 class=\"display-1\">Precipitation Data (cm)</h2>

--- a/reportrainyeartotals.php
+++ b/reportrainyeartotals.php
@@ -1,6 +1,6 @@
 <?php
 include('header.php');
-include('dbconn.php');
+require_once 'dbconn.php';
 
 echo "<div class=\"container-fluid\">
   <div class=\"d-sm-flex align-items-center justify-content-between mb-2\">

--- a/reporttempyeartotals.php
+++ b/reporttempyeartotals.php
@@ -1,6 +1,6 @@
 <?php
 include('header.php');
-include('dbconn.php');
+require_once 'dbconn.php';
 
 echo "<div class=\"container-fluid\">\n";
 echo "  <div class=\"card shadow mb-4\">\n";

--- a/reportwindyeartotals.php
+++ b/reportwindyeartotals.php
@@ -1,6 +1,6 @@
 <?php
 include('header.php');
-include('dbconn.php');
+require_once 'dbconn.php';
 
 echo "<div class=\"container\"><div class=card>
     <h1 class=\"display-4\">Monthly Wind Data Comparison</h1>

--- a/schedual.php
+++ b/schedual.php
@@ -1,6 +1,6 @@
 <?php
 // connect to MySQL
- include ('dbconn.php');
+ require_once 'dbconn.php';
  db_query('call clean_raw;');
 echo "Cleaned";
 flush();

--- a/winddata.php
+++ b/winddata.php
@@ -10,7 +10,7 @@ $sql = "SELECT wind_dir,
   FROM rawdata
   GROUP BY wind_dir";
 
- include('dbconn.php');
+ require_once 'dbconn.php';
  $result = db_query($sql);
 
 $rows = array();

--- a/windrose.php
+++ b/windrose.php
@@ -1,7 +1,7 @@
 
 <?php
   include ('header.php');
- include ('dbconn.php');
+ require_once 'dbconn.php';
  
  if(isset($_POST['DATE'])){$daterange  = $_POST['DATE'];}
  if(isset($_POST['DATEEND'])){$daterange2 = $_POST['DATEEND'];}
@@ -124,7 +124,7 @@ group by wind_dir";
 group by wind_dir";
      $sql = $sql1;
      }
- include ('dbconn.php');
+ require_once 'dbconn.php';
  $result = db_query($sql);
  echo "</div><div class=\"overflow-x-auto mb-3\">
  <table id=\"freqq\" class=\"min-w-full divide-y divide-gray-200 text-sm\">";
@@ -218,7 +218,7 @@ group by wind_dir";
  function selecttag($SQL, $name)
      {
      {
-         include ('dbconn.php');
+         require_once 'dbconn.php';
          //connect to a db
 $title="Select date";
         $resultg = db_query($SQL);


### PR DESCRIPTION
## Summary
- ensure `dbconn.php` is only included once across pages by replacing `include` with `require_once`

## Testing
- `php -l cleandata.php`
- `php -l css/index.php`
- `php -l extremes.php`
- `php -l getdata.php`
- `php -l getgraphdata.php`
- `php -l getgraphdata2.php`
- `php -l graph.php`
- `php -l header.php`
- `php -l index.php`
- `php -l iphone.php`
- `php -l maxmin.php`
- `php -l multidata.php`
- `php -l newgraph.php`
- `php -l records.php`
- `php -l report.php`
- `php -l reportrainyeartotals.php`
- `php -l reporttempyeartotals.php`
- `php -l reportwindyeartotals.php`
- `php -l schedual.php`
- `php -l winddata.php`
- `php -l windrose.php`


------
https://chatgpt.com/codex/tasks/task_e_68af3c424d38832eaa11d2140b17f2f8