### PR TITLE
Use UNIX_TIMESTAMP ranges for time filtering

### DIFF
--- a/getgraphdata2.php
+++ b/getgraphdata2.php
@@ -88,7 +88,7 @@ $max      = $itemmm;
 
 
 
- $sql    = "select dateTime * 1000 as datetime, round(MIN($itemmm),2) as datamin, round(MAX($itemmm),2) as datamax from $table where from_unixtime(dateTime) between ? and ?  GROUP BY hour(FROM_UNIXTIME(dateTime)),day(FROM_UNIXTIME(dateTime)) order by from_unixtime(dateTime)";
+$sql    = "select dateTime * 1000 as datetime, round(MIN($itemmm),2) as datamin, round(MAX($itemmm),2) as datamax from $table where dateTime BETWEEN UNIX_TIMESTAMP(?) AND UNIX_TIMESTAMP(?)  GROUP BY hour(FROM_UNIXTIME(dateTime)),day(FROM_UNIXTIME(dateTime)) order by dateTime";
  $stmt = mysqli_prepare($link, $sql);
  mysqli_stmt_bind_param($stmt, 'ss', $startTime, $endTime);
  mysqli_stmt_execute($stmt);

--- a/graph.php
+++ b/graph.php
@@ -35,10 +35,10 @@
 }
 
 
- $SQLHOT  = "SELECT round(MAX(`archive`.`$item`),2) FROM `weewx`.`archive` WHERE YEAR(FROM_UNIXTIME(`archive`.`dateTime`)) = YEAR(CURRENT_DATE()) limit 1";
- $SQLCOLD = "SELECT round(MIN(`archive`.`$item`),2) FROM `weewx`.`archive` WHERE YEAR(FROM_UNIXTIME(`archive`.`dateTime`)) = YEAR(CURRENT_DATE()) limit 1";
-$SQLHOTM  = "SELECT round(MAX(`archive`.`$item`),2) FROM `weewx`.`archive` WHERE MONTH(FROM_UNIXTIME(`archive`.`dateTime`)) = MONTH(FROM_UNIXTIME(CURRENT_DATE())) and YEAR(FROM_UNIXTIME(`archive`.`dateTime`)) = YEAR(FROM_UNIXTIME(CURRENT_DATE())) limit 1";
-$SQLCOLDM = "SELECT round(MIN(`archive`.`$item`),2) FROM `weewx`.`archive` WHERE MONTH(FROM_UNIXTIME(`archive`.`dateTime`)) = MONTH(FROM_UNIXTIME(CURRENT_DATE())) and YEAR(FROM_UNIXTIME(`archive`.`dateTime`)) = YEAR(FROM_UNIXTIME(CURRENT_DATE())) limit 1";
+$SQLHOT  = "SELECT round(MAX(`archive`.`$item`),2) FROM `weewx`.`archive` WHERE dateTime BETWEEN UNIX_TIMESTAMP(CONCAT(YEAR(CURRENT_DATE()),'-01-01')) AND UNIX_TIMESTAMP(CONCAT(YEAR(CURRENT_DATE()),'-12-31 23:59:59')) limit 1";
+$SQLCOLD = "SELECT round(MIN(`archive`.`$item`),2) FROM `weewx`.`archive` WHERE dateTime BETWEEN UNIX_TIMESTAMP(CONCAT(YEAR(CURRENT_DATE()),'-01-01')) AND UNIX_TIMESTAMP(CONCAT(YEAR(CURRENT_DATE()),'-12-31 23:59:59')) limit 1";
+$SQLHOTM  = "SELECT round(MAX(`archive`.`$item`),2) FROM `weewx`.`archive` WHERE dateTime BETWEEN UNIX_TIMESTAMP(DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')) AND UNIX_TIMESTAMP(LAST_DAY(CURRENT_DATE()) + INTERVAL 1 DAY) - 1 limit 1";
+$SQLCOLDM = "SELECT round(MIN(`archive`.`$item`),2) FROM `weewx`.`archive` WHERE dateTime BETWEEN UNIX_TIMESTAMP(DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')) AND UNIX_TIMESTAMP(LAST_DAY(CURRENT_DATE()) + INTERVAL 1 DAY) - 1 limit 1";
 
 
  function goget($link, $SQL) {

--- a/header.php
+++ b/header.php
@@ -8,8 +8,8 @@ require_once 'dbconn.php';
 $sql = "
     SELECT
         round(`archive`.`outTemp`,2) AS `outTemp`,
-        (SELECT round(`outTemp`,2) FROM `weewx`.`archive` WHERE DATE(FROM_UNIXTIME(`dateTime`)) = CURDATE() ORDER BY `outTemp` DESC LIMIT 1) AS `maxTemp`,
-        (SELECT round(`outTemp`,2) FROM `weewx`.`archive` WHERE DATE(FROM_UNIXTIME(`dateTime`)) = CURDATE() ORDER BY `outTemp` ASC LIMIT 1) AS `minTemp`
+        (SELECT round(`outTemp`,2) FROM `weewx`.`archive` WHERE dateTime BETWEEN UNIX_TIMESTAMP(CURDATE()) AND UNIX_TIMESTAMP(CURDATE() + INTERVAL 1 DAY) - 1 ORDER BY `outTemp` DESC LIMIT 1) AS `maxTemp`,
+        (SELECT round(`outTemp`,2) FROM `weewx`.`archive` WHERE dateTime BETWEEN UNIX_TIMESTAMP(CURDATE()) AND UNIX_TIMESTAMP(CURDATE() + INTERVAL 1 DAY) - 1 ORDER BY `outTemp` ASC LIMIT 1) AS `minTemp`
     FROM
         `weewx`.`archive`
     ORDER BY

--- a/multidata.php
+++ b/multidata.php
@@ -111,7 +111,7 @@ Select unix_timestamp(date) * 1000 as datetime,$item as data FROM `weather`.`raw
 order by t.datetime asc
 ";
 $sql_old2 = "Select unix_timestamp(date) * 1000 as datetime,$item as data FROM `weather`.`rawdata` where date > (NOW() - INTERVAL 1 DAY) order by date asc";
-$sql ="SELECT dateTime *1000 AS datetime, round($item,2) AS data FROM weewx.archive WHERE FROM_UNIXTIME(dateTime) > (NOW() - INTERVAL 1 DAY) ORDER BY dateTime ASC";
+$sql ="SELECT dateTime *1000 AS datetime, round($item,2) AS data FROM weewx.archive WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 1 DAY) AND UNIX_TIMESTAMP(NOW()) ORDER BY dateTime ASC";
 $stmt = mysqli_prepare($link, $sql);
 mysqli_stmt_execute($stmt);
 $result = mysqli_stmt_get_result($stmt);

--- a/newgraph.php
+++ b/newgraph.php
@@ -84,57 +84,57 @@ switch ($what) {
 
 switch ($scale) {
     case "hour":
-        $scalesql = "WHERE FROM_UNIXTIME(dateTime) > (NOW() - INTERVAL 2 HOUR) ";
+        $scalesql = "WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 2 HOUR) AND UNIX_TIMESTAMP(NOW()) ";
         $groupby = "GROUP BY hour(FROM_UNIXTIME(dateTime)),day(FROM_UNIXTIME(dateTime))";
         $xscale = "600 * 1000";
         break;
     case "hour":
-        $scalesql = "WHERE FROM_UNIXTIME(dateTime) > (NOW() - INTERVAL 12 HOUR) ";
+        $scalesql = "WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 12 HOUR) AND UNIX_TIMESTAMP(NOW()) ";
         $groupby = "GROUP BY hour(FROM_UNIXTIME(dateTime)),day(FROM_UNIXTIME(dateTime))";
         $xscale = "600 * 1000";
         break;
     case "day":
-        $scalesql = "WHERE FROM_UNIXTIME(dateTime) > (NOW() - INTERVAL 1 DAY) ";
+        $scalesql = "WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 1 DAY) AND UNIX_TIMESTAMP(NOW()) ";
         $groupby = "GROUP BY hour(FROM_UNIXTIME(dateTime)),day(FROM_UNIXTIME(dateTime))";
         $xscale = "3600 * 1000";
         break;
     case "48":
-        $scalesql = "WHERE FROM_UNIXTIME(dateTime) > (NOW() - INTERVAL 2 DAY) ";
+        $scalesql = "WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 2 DAY) AND UNIX_TIMESTAMP(NOW()) ";
         $groupby = "GROUP BY hour(FROM_UNIXTIME(dateTime)),day(FROM_UNIXTIME(dateTime))";
         $xscale = "3600 * 1000";
         break;
     case "week":
-        $scalesql = "WHERE FROM_UNIXTIME(dateTime) > (NOW() - INTERVAL 1 WEEK) ";
+        $scalesql = "WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 1 WEEK) AND UNIX_TIMESTAMP(NOW()) ";
         $groupby = "GROUP BY day(FROM_UNIXTIME(dateTime)),week(FROM_UNIXTIME(dateTime))";
         $xscale = "3600 * 1000 * 24";
         break;
     case "month":
-        $scalesql = "WHERE FROM_UNIXTIME(dateTime) > (NOW() - INTERVAL 1 MONTH) ";
+        $scalesql = "WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 1 MONTH) AND UNIX_TIMESTAMP(NOW()) ";
         $groupby = "GROUP BY day(FROM_UNIXTIME(dateTime)),month(FROM_UNIXTIME(dateTime))";
         $xscale = "3600 * 1000 * 24";
         break;
     case "qtr":
-        $scalesql = "WHERE FROM_UNIXTIME(dateTime) > (NOW() - INTERVAL 3 MONTH) ";
+        $scalesql = "WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 3 MONTH) AND UNIX_TIMESTAMP(NOW()) ";
         $groupby = "GROUP BY week(FROM_UNIXTIME(dateTime)),month(FROM_UNIXTIME(dateTime))";
         $xscale = "3600 * 1000 * 24 * 7";
         break;
     case "6m":
-        $scalesql = "WHERE FROM_UNIXTIME(dateTime) > (NOW() - INTERVAL 6 MONTH) ";
+        $scalesql = "WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 6 MONTH) AND UNIX_TIMESTAMP(NOW()) ";
         $groupby = "GROUP BY week(FROM_UNIXTIME(dateTime)),year(FROM_UNIXTIME(dateTime))";
         $xscale = "3600 * 1000 * 24 * 14";
         break;
     case "year":
-        $scalesql = "WHERE FROM_UNIXTIME(dateTime) > (NOW() - INTERVAL 1 YEAR) ";
+        $scalesql = "WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 1 YEAR) AND UNIX_TIMESTAMP(NOW()) ";
         $groupby = "GROUP BY month(FROM_UNIXTIME(dateTime)),year(FROM_UNIXTIME(dateTime))";
         $xscale = "3600 * 1000 * 24 * 7 * 52 / 12 ";
         break;
     case "all":
-        $scalesql = "WHERE FROM_UNIXTIME(dateTime) > (NOW() - INTERVAL 5 YEAR) ";
+        $scalesql = "WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 5 YEAR) AND UNIX_TIMESTAMP(NOW()) ";
         $groupby = "GROUP BY month(FROM_UNIXTIME(dateTime)),year(FROM_UNIXTIME(dateTime))";
         $xscale = "3600 * 1000 * 24 * 7 * 52 / 12";
         break;
     default:
-        $scalesql = "WHERE FROM_UNIXTIME(dateTime) > (NOW() - INTERVAL 1 DAY) ";
+        $scalesql = "WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 1 DAY) AND UNIX_TIMESTAMP(NOW()) ";
         $groupby = "GROUP BY hour(FROM_UNIXTIME(dateTime)),day(FROM_UNIXTIME(dateTime))";
         $xscale = "3600 * 1000";
 }

--- a/report.php
+++ b/report.php
@@ -25,7 +25,7 @@ FROM (
         DAY(FROM_UNIXTIME(dateTime)) AS day,
         SUM(rain) AS daily_rain_mm
     FROM archive
-    WHERE YEAR(FROM_UNIXTIME(dateTime)) = $year
+    WHERE dateTime BETWEEN UNIX_TIMESTAMP('$year-01-01') AND UNIX_TIMESTAMP('$year-12-31 23:59:59')
     GROUP BY year, month, day
 ) AS d
 JOIN (
@@ -40,7 +40,7 @@ JOIN (
             DAY(FROM_UNIXTIME(dateTime)) AS day,
             SUM(rain) AS daily_rain_mm
         FROM archive
-        WHERE YEAR(FROM_UNIXTIME(dateTime)) = $year
+        WHERE dateTime BETWEEN UNIX_TIMESTAMP('$year-01-01') AND UNIX_TIMESTAMP('$year-12-31 23:59:59')
         GROUP BY year, month, day
     ) AS daily_data
     GROUP BY year, month


### PR DESCRIPTION
## Summary
- replace FROM_UNIXTIME filters with numeric UNIX_TIMESTAMP comparisons
- tighten time queries to use BETWEEN ranges across dashboard endpoints

## Testing
- `php -l multidata.php`
- `php -l newgraph.php`
- `php -l report.php`
- `php -l getgraphdata2.php`
- `php -l graph.php`
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_68af3e899114832e94ae154292c030e2