### PR TITLE
Document stack and add Tabulator support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Repository Overview
 
-This project is a PHP-based weather web site. It retrieves data from a local `weewx` MySQL database and visualizes it with Highcharts.
+This project is a PHP-based weather web site. It retrieves data from a local `weewx` MySQL database and visualizes it with Highcharts for graphs. Interactive tables are built with [Tabulator](https://tabulator.info/) using its *Simple* theme and Tailwind utility classes.
 Record any additional project decisions or conventions in this file.
 
 ## Key Files
@@ -13,6 +13,9 @@ Record any additional project decisions or conventions in this file.
 - PHP files generally use two-space indentation.
 - There is no automated test suite; run `php -l <file>` on any modified PHP file to check syntax.
 - Static assets like CSS, images, and JavaScript libraries live in the project root or dedicated folders (`css`, `jpg`, etc.), with shared JavaScript collected under `frontend/js/`.
+- Tailwind CSS provides project-wide styling and Font Awesome supplies icons.
+- Headings use bold **Roboto**, body text **Inter**, and buttons or highlights light **Source Sans Pro**.
+- Sections should be wrapped in card components (`bg-white shadow rounded p-4`).
 
 ## Verification
 Before committing, run syntax checks for changed PHP files. Example:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Weather
 
-This repository hosts a PHP-based weather website. Some scripts still reside in the project root, but shared JavaScript libraries now live under `frontend/js/`.
+This repository hosts a PHP-based weather website. Graphs are rendered with [Highcharts](https://www.highcharts.com/), while interactive tables use [Tabulator](https://tabulator.info/) with its *Simple* theme and Tailwind utility classes. Tailwind CSS handles styling, Font Awesome provides icons, and the layout wraps sections in card components. Typography follows: headings in bold Roboto, body text in Inter, and buttons or highlights in light Source Sans Pro. Shared JavaScript libraries live under `frontend/js/`.
 
 ## Planned reorganization
 

--- a/extremes.php
+++ b/extremes.php
@@ -35,7 +35,7 @@ require_once 'dbconn.php';
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div id="dayChart" class="h-96"></div>
       <div>
-        <table class="table-auto w-full text-sm">
+        <table class="text-sm" data-tabulator="true">
           <thead class="bg-gray-200">
             <tr><th class="px-2 py-1">Metric</th><th class="px-2 py-1">Max</th><th class="px-2 py-1">Min</th></tr>
           </thead>
@@ -57,7 +57,7 @@ require_once 'dbconn.php';
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div id="weekChart" class="h-96"></div>
       <div>
-        <table class="table-auto w-full text-sm">
+        <table class="text-sm" data-tabulator="true">
           <thead class="bg-gray-200">
             <tr><th class="px-2 py-1">Metric</th><th class="px-2 py-1">Max</th><th class="px-2 py-1">Min</th></tr>
           </thead>
@@ -79,7 +79,7 @@ require_once 'dbconn.php';
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div id="monthChart" class="h-96"></div>
       <div>
-        <table class="table-auto w-full text-sm">
+        <table class="text-sm" data-tabulator="true">
           <thead class="bg-gray-200">
             <tr><th class="px-2 py-1">Metric</th><th class="px-2 py-1">Max</th><th class="px-2 py-1">Min</th></tr>
           </thead>

--- a/frontend/js/tabulator-init.js
+++ b/frontend/js/tabulator-init.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('table[data-tabulator]').forEach(table => {
+    const headers = Array.from(table.querySelectorAll('thead th')).map(th => ({
+      title: th.textContent.trim(),
+      field: th.textContent.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_')
+    }));
+    const data = Array.from(table.querySelectorAll('tbody tr')).map(tr => {
+      const cells = tr.querySelectorAll('td');
+      const row = {};
+      headers.forEach((h, i) => {
+        row[h.field] = cells[i] ? cells[i].textContent.trim() : '';
+      });
+      return row;
+    });
+    const container = document.createElement('div');
+    container.className = 'w-full';
+    table.parentNode.replaceChild(container, table);
+    new Tabulator(container, {
+      data,
+      columns: headers,
+      layout: 'fitDataTable'
+    });
+  });
+});

--- a/header.php
+++ b/header.php
@@ -48,6 +48,9 @@ $minTemp = $row['minTemp'];
   <link rel="home" href="/" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://kit.fontawesome.com/55c3f37ab0.js" crossorigin="anonymous"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
+  <link href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_simple.min.css" rel="stylesheet">
+  <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
   <script src="https://code.highcharts.com/stock/highstock.js"></script>
   <script src="https://code.highcharts.com/highcharts-more.js"></script>
   <script src="https://code.highcharts.com/modules/boost.js"></script>
@@ -61,13 +64,12 @@ $minTemp = $row['minTemp'];
   <link rel="manifest" href="/manifest.json">
   <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
   <meta name="theme-color" content="#ffffff">
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      document.querySelectorAll('table').forEach(function(table) {
-        table.classList.add('table-auto', 'w-full');
-      });
-    });
-  </script>
+  <script src="/frontend/js/tabulator-init.js"></script>
+  <style>
+    body { font-family: 'Inter', sans-serif; }
+    h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
+    button, .highlight { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
+  </style>
 </head>
   <body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
   <button id="sidebar-toggle" class="p-2 text-gray-900 dark:text-gray-100 md:hidden fixed top-4 left-4 bg-white dark:bg-gray-800 rounded" aria-label="Toggle navigation">


### PR DESCRIPTION
## Summary
- document frontend stack in README and AGENTS
- add Tabulator, fonts, and initialization script in header
- enable Tabulator tables on extremes page

## Testing
- `php -l header.php`
- `php -l extremes.php`


------
https://chatgpt.com/codex/tasks/task_e_68af43094844832e94932abcfb6d72ae