### PR TITLE
Move mobile menu toggle to right with top z-index

### DIFF
--- a/header.php
+++ b/header.php
@@ -74,13 +74,13 @@ $minTemp = $row['minTemp'];
   </style>
 </head>
   <body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-  <button id="sidebar-toggle" class="p-2 text-gray-900 dark:text-gray-100 md:hidden fixed top-4 left-4 bg-white dark:bg-gray-800 rounded" aria-label="Toggle navigation">
+  <button id="sidebar-toggle" class="p-2 text-gray-900 dark:text-gray-100 md:hidden fixed top-4 right-4 z-50 bg-white dark:bg-gray-800 rounded" aria-label="Toggle navigation">
     <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
     </svg>
   </button>
     <div class="flex min-h-screen">
-      <aside id="sidebar" class="bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 w-64 space-y-2 py-4 px-2 absolute inset-y-0 left-0 transform -translate-x-full md:relative md:translate-x-0 transition duration-200 ease-in-out">
+      <aside id="sidebar" class="bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 w-64 space-y-2 py-4 px-2 absolute inset-y-0 left-0 z-40 transform -translate-x-full md:relative md:translate-x-0 transition duration-200 ease-in-out">
       <a id="navname" class="flex items-center space-x-2 px-4" href="/#">
         <img src="/safari-pinned-tab.svg" class="w-8 h-8" alt="">
         <span>Wheathampstead Weather</span>


### PR DESCRIPTION
## Summary
- Place mobile sidebar toggle button on the right and ensure it stays above other elements
- Set sidebar z-index below button to preserve layering

## Testing
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_68af49b04c84832e8ab4295b4744a865