### PR TITLE
Enable Tabulator column groups

### DIFF
--- a/frontend/js/tabulator-init.js
+++ b/frontend/js/tabulator-init.js
@@ -1,23 +1,63 @@
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('table[data-tabulator]').forEach(table => {
-    const headers = Array.from(table.querySelectorAll('thead th')).map(th => ({
-      title: th.textContent.trim(),
-      field: th.textContent.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_')
-    }));
+    const headerRows = Array.from(table.querySelectorAll('thead tr'));
+    let columns = [];
+    let flatHeaders = [];
+
+    if (headerRows.length > 1) {
+      const topCells = Array.from(headerRows[0].children);
+      const secondCells = Array.from(headerRows[1].children);
+      let secondIndex = 0;
+
+      topCells.forEach(cell => {
+        const title = cell.textContent.trim();
+        const colspan = parseInt(cell.getAttribute('colspan') || '1', 10);
+        const rowspan = parseInt(cell.getAttribute('rowspan') || '1', 10);
+
+        if (colspan > 1) {
+          const groupCols = [];
+          for (let i = 0; i < colspan; i++) {
+            const subCell = secondCells[secondIndex++];
+            const subTitle = subCell.textContent.trim();
+            const field = subTitle.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+            groupCols.push({ title: subTitle, field });
+            flatHeaders.push({ title: subTitle, field });
+          }
+          columns.push({ title, columns: groupCols });
+        } else {
+          const field = title.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+          columns.push({ title, field });
+          flatHeaders.push({ title, field });
+          if (rowspan === 1) {
+            secondIndex++;
+          }
+        }
+      });
+    } else {
+      flatHeaders = Array.from(table.querySelectorAll('thead th')).map(th => {
+        return {
+          title: th.textContent.trim(),
+          field: th.textContent.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_')
+        };
+      });
+      columns = flatHeaders;
+    }
+
     const data = Array.from(table.querySelectorAll('tbody tr')).map(tr => {
       const cells = tr.querySelectorAll('td');
       const row = {};
-      headers.forEach((h, i) => {
+      flatHeaders.forEach((h, i) => {
         row[h.field] = cells[i] ? cells[i].textContent.trim() : '';
       });
       return row;
     });
+
     const container = document.createElement('div');
     container.className = 'w-full';
     table.parentNode.replaceChild(container, table);
     new Tabulator(container, {
       data,
-      columns: headers,
+      columns,
       layout: 'fitDataTable'
     });
   });

--- a/report.php
+++ b/report.php
@@ -85,7 +85,10 @@ mysqli_free_result($result);
 
 // Generate the HTML table
 echo "<table class=\"min-w-full divide-y divide-gray-200 border border-gray-300 text-sm\" data-tabulator=\"true\">";
-echo "<thead class=\"bg-gray-50\"><tr><th>YR</th><th>MO</th><th>TOTAL</th><th>MAX DAY</th><th>Over 0.03</th><th>Over 0.30</th><th>Over 3.00</th></tr></thead><tbody>";
+echo "<thead class=\"bg-gray-50\">\n";
+echo "  <tr><th rowspan=\"2\">YR</th><th rowspan=\"2\">MO</th><th rowspan=\"2\">TOTAL</th><th rowspan=\"2\">MAX DAY</th><th colspan=\"3\">Days Over</th></tr>\n";
+echo "  <tr><th>0.03</th><th>0.30</th><th>3.00</th></tr>\n";
+echo "</thead><tbody>";
 
 for ($month = 1; $month <= 12; $month++) {
     if (isset($monthly_data[$month])) {


### PR DESCRIPTION
## Summary
- Detect multi-row table headers and build Tabulator column groups
- Group precipitation report's threshold columns under a "Days Over" heading

## Testing
- `php -l report.php`


------
https://chatgpt.com/codex/tasks/task_e_68af4bd9e1e4832e9785dd583214ef4d