### PR TITLE
Fix invalid JSON in multidata endpoint

### DIFF
--- a/multidata.php
+++ b/multidata.php
@@ -167,7 +167,7 @@ $result = mysqli_stmt_get_result($stmt);
    header('Content-Type: application/json');
  }
 
- echo "/* console.log(' sql=$sql ,start = $data, end = $end, startTime = $startTime, endTime = $endTime '); */";
+ // Removed debug comment to ensure valid JSON responses
  if ($isJsonp) {
    echo $callback . "([\n" . join(",\n", $rows) . "\n]);";
  } else {


### PR DESCRIPTION
## Summary
- remove leftover console.log debug comment from multidata.php so JSON parses cleanly

## Testing
- `php -l multidata.php`


------
https://chatgpt.com/codex/tasks/task_e_68af891986ec832ea03e08d23f18c395