### PR TITLE
Group temperature table by year with highlighted extremes

### DIFF
--- a/frontend/js/tabulator-init.js
+++ b/frontend/js/tabulator-init.js
@@ -3,6 +3,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const headerRows = Array.from(table.querySelectorAll('thead tr'));
     let columns = [];
     let flatHeaders = [];
+    const cellFormatter = cell => {
+      const data = cell.getData();
+      const field = cell.getField();
+      const cls = data[field + '_class'];
+      if (cls) {
+        cls.split(' ').forEach(c => cell.getElement().classList.add(c));
+      }
+      return data[field];
+    };
 
     if (headerRows.length > 1) {
       const topCells = Array.from(headerRows[0].children);
@@ -20,13 +29,13 @@ document.addEventListener('DOMContentLoaded', () => {
             const subCell = secondCells[secondIndex++];
             const subTitle = subCell.textContent.trim();
             const field = subTitle.toLowerCase().replace(/[^a-z0-9]+/g, '_');
-            groupCols.push({ title: subTitle, field });
+            groupCols.push({ title: subTitle, field, formatter: cellFormatter });
             flatHeaders.push({ title: subTitle, field });
           }
           columns.push({ title, columns: groupCols });
         } else {
           const field = title.toLowerCase().replace(/[^a-z0-9]+/g, '_');
-          columns.push({ title, field });
+          columns.push({ title, field, formatter: cellFormatter });
           flatHeaders.push({ title, field });
           if (rowspan === 1) {
             secondIndex++;
@@ -40,7 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
           field: th.textContent.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_')
         };
       });
-      columns = flatHeaders;
+      columns = flatHeaders.map(h => ({ ...h, formatter: cellFormatter }));
     }
 
     const data = Array.from(table.querySelectorAll('tbody tr')).map(tr => {
@@ -48,6 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const row = {};
       flatHeaders.forEach((h, i) => {
         row[h.field] = cells[i] ? cells[i].textContent.trim() : '';
+        row[h.field + '_class'] = cells[i] ? cells[i].getAttribute('class') || '' : '';
       });
       return row;
     });

--- a/reporttempyeartotals.php
+++ b/reporttempyeartotals.php
@@ -83,14 +83,19 @@ sort($months);
 echo "        <table class=\"min-w-full divide-y divide-gray-200 border border-gray-300 text-sm\" data-tabulator=\"true\">\n";
 echo "          <thead class=\"bg-gray-50\">\n";
 echo "          <tr>\n";
-echo "            <th>Month</th>";
+echo "            <th rowspan=\"2\">Month</th>";
 
 // Header cells for each year
 foreach ($years as $year) {
-  echo "<th>$year Avg</th><th>$year Max</th><th>$year Min</th>";
+  echo "            <th colspan=\"3\">$year</th>";
 }
 
-echo "</tr>\n          </thead>\n          <tbody>";
+echo "          </tr>\n";
+echo "          <tr>";
+foreach ($years as $year) {
+  echo "            <th>Avg</th><th>Max</th><th>Min</th>";
+}
+echo "          </tr>\n          </thead>\n          <tbody>";
 
 // Table rows for each month
 foreach ($months as $month) {
@@ -107,28 +112,26 @@ foreach ($months as $month) {
         $max_temp = $data['max_temp'];
         $min_temp = $data['min_temp'];
 
-        // Styles for max and min temperatures
-        $max_style = "text-align: right;";
-        $min_style = "text-align: right;";
+        $avg_class = "text-right";
+        $max_class = "text-right";
+        $min_class = "text-right";
 
-        // Highlight the maximum temperature
         if (in_array($year, $years_with_max_temp[$month])) {
-            $max_style .= " color: red;";
+            $max_class .= " text-red-500";
         }
 
-        // Highlight the minimum temperature
         if (in_array($year, $years_with_min_temp[$month])) {
-            $min_style .= " color: blue;";
+            $min_class .= " text-blue-500";
         }
 
-        echo "            <td style=\"text-align: right;\">$avg_temp</td>";
-        echo "            <td style=\"$max_style\">$max_temp</td>";
-        echo "            <td style=\"$min_style\">$min_temp</td>";
+        echo "            <td class=\\\"$avg_class\\\">$avg_temp</td>";
+        echo "            <td class=\\\"$max_class\\\">$max_temp</td>";
+        echo "            <td class=\\\"$min_class\\\">$min_temp</td>";
     } else {
         // No data for this month and year
-        echo "            <td style=\"text-align: right;\">-</td>";
-        echo "            <td style=\"text-align: right;\">-</td>";
-        echo "            <td style=\"text-align: right;\">-</td>";
+        echo "            <td class=\\\"text-right\\\">-</td>";
+        echo "            <td class=\\\"text-right\\\">-</td>";
+        echo "            <td class=\\\"text-right\\\">-</td>";
     }
   }
 


### PR DESCRIPTION
## Summary
- Group monthly temperature report columns by year using Tabulator's column grouping.
- Preserve cell classes in Tabulator tables and add formatter to apply color styling.
- Mark yearly monthly temperature maxima in red and minima in blue for easy comparison.

## Testing
- `php -l reporttempyeartotals.php`


------
https://chatgpt.com/codex/tasks/task_e_68af8a97e39c832e980f97c706ed86f6