### PR TITLE
Fix rain today link using lowercase parameter

### DIFF
--- a/index.php
+++ b/index.php
@@ -63,7 +63,7 @@ require_once 'dbconn.php';
       </a>
     </div>
     <div class="bg-white border-l-4 border-blue-500 shadow rounded p-4">
-      <a href="http://www.smeird.com/newgraph.php?WHAT=Rain&SCALE=day" class="block hover:no-underline">
+      <a href="http://www.smeird.com/newgraph.php?WHAT=rain&SCALE=day" class="block hover:no-underline">
         <div class="flex items-center">
           <div class="flex-grow mr-2">
             <div class="text-xs font-bold text-blue-500 uppercase mb-1">Rain Today</div>


### PR DESCRIPTION
## Summary
- update Rain Today home page link to use lowercase `rain` parameter

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68af8bca7320832ea13cadfbe39ce59b