### PR TITLE
Align sidebar graph options with backend

### DIFF
--- a/test.php
+++ b/test.php
@@ -8,17 +8,13 @@ $type = $_GET['TYPE'] ?? '';
     <label for="what" class="block text-sm font-medium text-blue-900">Data</label>
     <select id="what" name="WHAT" class="mt-1 block w-full rounded border-blue-300 bg-white p-2 text-blue-900 focus:border-blue-500 focus:ring focus:ring-blue-500">
       <option value="outTemp">Outside Temperature</option>
-      <option value="outHumidity">Out Side Humidity</option>
+      <option value="outHumidity">Outside Humidity</option>
       <option value="windSpeed">Wind Speed</option>
       <option value="windDir">Wind Direction</option>
       <option value="windGust">Wind Gust Speed</option>
       <option value="windGustDir">Wind Gust Direction</option>
       <option value="barometer">Barometer</option>
       <option value="rain">Rain</option>
-      <option value="rainRate">Rain Rate</option>
-      <option value="dewpoint">Dew Point</option>
-      <option value="windchill">Wind chill</option>
-      <option value="consBatteryVoltage">Console Battery Voltage</option>
       <option value="inTemp">Inside Temperature</option>
       <option value="inHumidity">Inside Humidity</option>
     </select>
@@ -26,7 +22,7 @@ $type = $_GET['TYPE'] ?? '';
   <div>
     <label for="typey" class="block text-sm font-medium text-blue-900">Graph Type</label>
     <select id="typey" name="TYPE" class="mt-1 block w-full rounded border-blue-300 bg-white p-2 text-blue-900 focus:border-blue-500 focus:ring focus:ring-blue-500">
-      <option value="Standard">Standard</option>
+      <option value="STANDARD">Standard</option>
       <option value="MINMAX">Min &amp; Max</option>
     </select>
   </div>
@@ -34,8 +30,7 @@ $type = $_GET['TYPE'] ?? '';
     <label for="scale" class="block text-sm font-medium text-blue-900">Time Scale</label>
     <select id="scale" name="SCALE" class="mt-1 block w-full rounded border-blue-300 bg-white p-2 text-blue-900 focus:border-blue-500 focus:ring focus:ring-blue-500">
       <option value="hour">Hour</option>
-      <option value="12hour">12 Hour</option>
-      <option value="Day">Day</option>
+      <option value="day">Day</option>
       <option value="48">48hrs</option>
       <option value="week">Week</option>
       <option value="month">Month</option>


### PR DESCRIPTION
## Summary
- Remove unsupported data metrics from the sidebar graph selector
- Ensure graph type and time scale values match `newgraph.php` expectations

## Testing
- `php -l test.php`


------
https://chatgpt.com/codex/tasks/task_e_68af8d12f228832e9bc60578c70181d9