### PR TITLE
Fix rain by year table rendering

### DIFF
--- a/reportrainyeartotals.php
+++ b/reportrainyeartotals.php
@@ -116,8 +116,6 @@ foreach ($months as $month) {
             }
             $style_attr = $border_style ? " style=\\\"$border_style\\\"" : "";
             echo "            <td class=\"$cell_class\"$style_attr>$rain_mm</td>";
-echo "            <td class=\"$cell_class\">$rain_mm</td>";
->
         } else {
             echo "            <td class=\"text-right\">0</td>"; // No data for this month and year
         }


### PR DESCRIPTION
## Summary
- fix syntax error in yearly rainfall report

## Testing
- `php -l reportrainyeartotals.php`
- `php reportrainyeartotals.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af962629e0832eb0642830e473824f