### PR TITLE
Optimize queries for large dataset

### DIFF
--- a/getgraphdata.php
+++ b/getgraphdata.php
@@ -107,20 +107,21 @@ $item = $allowedItems[$itemKey];
 
 
 
-  $sql = "SELECT dateTime * 1000 AS datey, round($item,1) AS data FROM $table WHERE from_unixtime(dateTime) BETWEEN ? AND ? ORDER BY datey";
- $stmt = mysqli_prepare($link, $sql);
- mysqli_stmt_bind_param($stmt, 'ss', $startTime, $endTime);
- mysqli_stmt_execute($stmt);
- $result = mysqli_stmt_get_result($stmt);
+  $limit = 5000;
+  $sql = "SELECT dateTime * 1000 AS datey, round($item,1) AS data FROM $table WHERE from_unixtime(dateTime) BETWEEN ? AND ? ORDER BY datey LIMIT $limit";
+  $stmt = mysqli_prepare($link, $sql);
+  mysqli_stmt_bind_param($stmt, 'ss', $startTime, $endTime);
+  mysqli_stmt_execute($stmt);
+  $result = mysqli_stmt_get_result($stmt);
 
  if ($item == "rainn") {
      mysqli_free_result($result);
      mysqli_stmt_close($stmt);
-     $sql2 = "SELECT unix_timestamp(t1.dateTime) * 1000 as datetime, IFNULL((t1.rain - t2.rain),0) as data FROM archive t1 LEFT OUTER JOIN archive t2 ON t2.dateTime = (SELECT MAX(dateTime) FROM archive WHERE dateTime < t1.dateTime) WHERE t1.dateTime BETWEEN ? AND ? ORDER BY t1.dateTime limit 0, 5000";
-     $stmt = mysqli_prepare($link, $sql2);
-     mysqli_stmt_bind_param($stmt, 'ss', $startTime, $endTime);
-     mysqli_stmt_execute($stmt);
-     $result = mysqli_stmt_get_result($stmt);
+    $sql2 = "SELECT unix_timestamp(t1.dateTime) * 1000 as datetime, IFNULL((t1.rain - t2.rain),0) as data FROM archive t1 LEFT OUTER JOIN archive t2 ON t2.dateTime = (SELECT MAX(dateTime) FROM archive WHERE dateTime < t1.dateTime) WHERE t1.dateTime BETWEEN ? AND ? ORDER BY t1.dateTime LIMIT $limit";
+    $stmt = mysqli_prepare($link, $sql2);
+    mysqli_stmt_bind_param($stmt, 'ss', $startTime, $endTime);
+    mysqli_stmt_execute($stmt);
+    $result = mysqli_stmt_get_result($stmt);
 
      $sql3 = "select $item as data from $table where dateTime between ? and ? order by dateTime limit 1";
      $stmt2 = mysqli_prepare($link, $sql3);

--- a/records.php
+++ b/records.php
@@ -3,20 +3,22 @@ include('header.php');
 require_once 'dbconn.php';
 
 $SQLHOT = "SELECT
-  ROUND(`archive`.`outTemp`, 1) AS temp,
-  FROM_UNIXTIME(`archive`.`dateTime`, '%Y-%m-%d %H:%i:%s') AS dt
+  ROUND(archive.outTemp, 1) AS temp,
+  FROM_UNIXTIME(archive.dateTime, '%Y-%m-%d %H:%i:%s') AS dt
 FROM
-  `weewx`.`archive`
-WHERE
-  `archive`.`outTemp` = (SELECT MAX(`outTemp`) FROM `weewx`.`archive`);";
+  weewx.archive
+ORDER BY
+  archive.outTemp DESC
+LIMIT 1";
 
 $SQLCOLD = "SELECT
-  ROUND(`archive`.`outTemp`, 1) AS temp,
-  FROM_UNIXTIME(`archive`.`dateTime`, '%Y-%m-%d %H:%i:%s') AS dt
+  ROUND(archive.outTemp, 1) AS temp,
+  FROM_UNIXTIME(archive.dateTime, '%Y-%m-%d %H:%i:%s') AS dt
 FROM
-  `weewx`.`archive`
-WHERE
-  `archive`.`outTemp` = (SELECT MIN(`outTemp`) FROM `weewx`.`archive`);";
+  weewx.archive
+ORDER BY
+  archive.outTemp ASC
+LIMIT 1";
 
 $SQLLONGHOT = "SELECT
   COUNT(DISTINCT DATE(FROM_UNIXTIME(dateTime)))
@@ -33,20 +35,22 @@ WHERE
   `archive`.`outTemp` < -5;";
 
 $SQLGUST = "SELECT
-  ROUND(`archive`.`windGust`, 1) AS gust,
-  FROM_UNIXTIME(`archive`.`dateTime`, '%Y-%m-%d %H:%i:%s') AS dt
+  ROUND(archive.windGust, 1) AS gust,
+  FROM_UNIXTIME(archive.dateTime, '%Y-%m-%d %H:%i:%s') AS dt
 FROM
-  `weewx`.`archive`
-WHERE
-  `archive`.`windGust` = (SELECT MAX(`windGust`) FROM `weewx`.`archive`);";
+  weewx.archive
+ORDER BY
+  archive.windGust DESC
+LIMIT 1";
 
 $SQLRAINRATE = "SELECT
-  ROUND(`archive`.`rainRate`, 1) AS rate,
-  FROM_UNIXTIME(`archive`.`dateTime`, '%Y-%m-%d %H:%i:%s') AS dt
+  ROUND(archive.rainRate, 1) AS rate,
+  FROM_UNIXTIME(archive.dateTime, '%Y-%m-%d %H:%i:%s') AS dt
 FROM
-  `weewx`.`archive`
-WHERE
-  `archive`.`rainRate` = (SELECT MAX(`rainRate`) FROM `weewx`.`archive`);";
+  weewx.archive
+ORDER BY
+  archive.rainRate DESC
+LIMIT 1";
 
 $resultHot = db_query($SQLHOT);
 $hot = mysqli_fetch_assoc($resultHot);

--- a/winddata.php
+++ b/winddata.php
@@ -3,11 +3,12 @@
 // within different ranges for each direction.
 
 $sql = "SELECT wind_dir,
-    COUNT(CASE WHEN wind_ave>=0 AND wind_ave <=2 THEN wind_ave ELSE NULL END) AS 'A',
-    COUNT(CASE WHEN wind_ave>=2 AND wind_ave <=4 THEN wind_ave ELSE NULL END) AS 'B',
-    COUNT(CASE WHEN wind_ave>=4 AND wind_ave <=6 THEN wind_ave ELSE NULL END) AS 'C',
-    COUNT(CASE WHEN wind_ave>=6 AND wind_ave <=8 THEN wind_ave ELSE NULL END) AS 'D'
+    COUNT(CASE WHEN wind_ave>=0 AND wind_ave <=2 THEN 1 END) AS A,
+    COUNT(CASE WHEN wind_ave>=2 AND wind_ave <=4 THEN 1 END) AS B,
+    COUNT(CASE WHEN wind_ave>=4 AND wind_ave <=6 THEN 1 END) AS C,
+    COUNT(CASE WHEN wind_ave>=6 AND wind_ave <=8 THEN 1 END) AS D
   FROM rawdata
+  WHERE date >= DATE_SUB(NOW(), INTERVAL 1 YEAR)
   GROUP BY wind_dir";
 
  require_once 'dbconn.php';


### PR DESCRIPTION
## Summary
- Streamline record lookups with `ORDER BY ... LIMIT 1` to leverage indexes
- Restrict wind rose aggregation to recent year
- Cap graph data responses to 5k rows for faster charts

## Testing
- `php -l records.php`
- `php -l winddata.php`
- `php -l getgraphdata.php`


------
https://chatgpt.com/codex/tasks/task_e_68af96855db0832e965c4aec61f92a75