### PR TITLE
Ensure all months displayed in yearly temperature table

### DIFF
--- a/reporttempyeartotals.php
+++ b/reporttempyeartotals.php
@@ -25,7 +25,8 @@ ORDER BY year, month;
 // Initialize arrays to hold the data
 $temperature_data = array();
 $years = array();
-$months = array();
+// Ensure all twelve months appear in the table, even if no data exists
+$months = range(1, 12);
 
 // Initialize arrays to hold maximum and minimum temperatures per month
 $max_temps_per_month = array();
@@ -41,12 +42,9 @@ while ($row = mysqli_fetch_assoc($result)) {
   $max_temp = $row['max_temp'];
   $min_temp = $row['min_temp'];
 
-  // Store unique years and months
+  // Store unique years
   if (!in_array($year, $years)) {
     $years[] = $year;
-  }
-  if (!in_array($month, $months)) {
-    $months[] = $month;
   }
 
   // Store the temperature data
@@ -75,9 +73,8 @@ while ($row = mysqli_fetch_assoc($result)) {
 
 mysqli_free_result($result);
 
-// Sort the years and months
+// Sort the years; months are already in chronological order
 sort($years);
-sort($months);
 
 // Generate the HTML table
 echo "        <table class=\"min-w-full divide-y divide-gray-200 border border-gray-300 text-sm\" data-tabulator=\"true\">\n";


### PR DESCRIPTION
## Summary
- Include all twelve months in temperature-by-year report even when database lacks records
- Simplify month handling and sort years only

## Testing
- `php -l reporttempyeartotals.php`


------
https://chatgpt.com/codex/tasks/task_e_68af9754be24832e82fc0a7ada4ad8d9