### PR TITLE
Display live webcam snapshot without caching

### DIFF
--- a/picture.php
+++ b/picture.php
@@ -1,41 +1,16 @@
 <?php
- include ('header.php');
+header("Cache-Control: no-store, no-cache, must-revalidate");
+header("Pragma: no-cache");
+header("Expires: 0");
+include('header.php');
 ?>
+<div>
+  <div class="flex flex-col sm:flex-row items-center justify-between mb-2">
+    <h1 class="text-2xl text-gray-800">Webcam</h1>
+  </div>
+  <div class="bg-white shadow rounded p-4">
+    <img src="/snap.jpeg?<?php echo time(); ?>" alt="Latest webcam snapshot" class="w-full h-auto rounded">
+  </div>
+</div>
+<?php include('footer.php'); ?>
 
-
-<!DOCTYPE html>
- <html>
-   <head>
-   <title></title>
-   <meta charset="utf-8" />
-   <script type="text/javascript" src="/assets/vxgplayer-1.8.31/vxgplayer-1.8.31.min.js"></script>
-   <link href="/assets/vxgplayer-1.8.31/vxgplayer-1.8.31.min.css" rel="stylesheet" />
- </head>
-  <body>
-    <div  class="vxgplayer"
-    id="vxg_media_player1"
-    width="640"
-    height="480"
-    url="rtsp://10.0.179.16:7447/5ee682bb4f0c8f57ed89534c_0"
-    nmf-src="/assets/vxgplayer-1.8.31/pnacl/Release/media_player.nmf"
-    nmf-path="media_player.nmf"
-    useragent-prefix="MMP/3.0"
-    latency="10000"
-    autohide="2"
-    volume="0.7"
-    avsync
-    autostart
-    controls
-    mute
-    aspect-ratio
-    aspect-ratio-mode="1"
-    auto-reconnect
-    connection-timeout="5000"
-    connection-udp="0"
-    custom-digital-zoom></div>
- </body>
- </html>
-<?
-
- include ('footer.php');
-?>


### PR DESCRIPTION
## Summary
- Replace outdated webcam stream with current `snap.jpeg` image on the Webcam page
- Send no-cache headers and append timestamp to prevent image caching

## Testing
- `php -l picture.php`


------
https://chatgpt.com/codex/tasks/task_e_68b00406fa00832eb01ee8b2ee43d7b9