### PR TITLE
Use default colors for Highcharts graphs

### DIFF
--- a/graph.php
+++ b/graph.php
@@ -171,7 +171,6 @@ $SQLCOLDM = "SELECT round(MIN(`archive`.`$item`),1) FROM `weewx`.`archive` WHERE
                 },
                 plotLines : [{
                     value : <?php echo $cold; ?>,
-                    color : 'blue',
                     dashStyle : 'longdash',
                     width : 1,
                     label : {
@@ -183,7 +182,6 @@ $SQLCOLDM = "SELECT round(MIN(`archive`.`$item`),1) FROM `weewx`.`archive` WHERE
                     }
                 }, {
                     value : <?php echo $hot; ?>,
-                    color : 'red',
                     dashStyle : 'longdash',
                     width : 1,
                     label : {
@@ -195,7 +193,6 @@ $SQLCOLDM = "SELECT round(MIN(`archive`.`$item`),1) FROM `weewx`.`archive` WHERE
                     }
                 },{
                     value : <?php echo $coldm; ?>,
-                    color : 'blue',
                     dashStyle : 'shortdash',
                     width : 1,
                     label : {
@@ -208,7 +205,6 @@ $SQLCOLDM = "SELECT round(MIN(`archive`.`$item`),1) FROM `weewx`.`archive` WHERE
                     }
                 }, {
                     value : <?php echo $hotm; ?>,
-                    color : 'red',
                     dashStyle : 'shortdash',
                     width : 1,
                     label : {
@@ -227,8 +223,6 @@ $SQLCOLDM = "SELECT round(MIN(`archive`.`$item`),1) FROM `weewx`.`archive` WHERE
                             name: '<?php echo $item; ?>',
                             data: data,
                             id: 'primary',
-                            color: '#FF0000',
-                            negativeColor: '#0088FF',
                             lineWidth: 1
                         }]
                 });

--- a/graph2.php
+++ b/graph2.php
@@ -107,8 +107,6 @@ if(isset($_GET['FULL'])) {
                             data: data,
                             lineWidth: 1,
                             id: 'primary',
-                            color: '#FF0000',
-                            negativeColor: '#0088FF',
                             dataGrouping: {
                                 enabled: false
                             }

--- a/graph3.php
+++ b/graph3.php
@@ -20,42 +20,38 @@ if(isset($_GET['FULL'])) {
                         fetch('multidata.php?item=' + encodeURIComponent(name.toLowerCase()))
                           .then(response => response.json())
                           .then(function(data) {
-                            colorr = '#89A54E';
                             if (name == 'rain') {
                                 typee = 'column';
                             } else {
                                 typee = 'spline';
                             }
 
-
                             if (name == 'inHumidity') {
-                                dashStylee = 'ShortDashDot', colorr = '#DDA54E', axis = 3;
+                                dashStylee = 'ShortDashDot'; axis = 3;
                             }
                             if (name == 'outHumidity') {
-                                dashStylee = 'ShortDash', colorr = '#DDA54E', axis = 3;
+                                dashStylee = 'ShortDash'; axis = 3;
                             }
                             if (name == 'inTemp') {
                                 axis = 0;
                             }
                             if (name == 'outTemp') {
-                                dashStylee = 'ShortDot', colorr = '#ccA54E', axis = 0;
+                                dashStylee = 'ShortDot'; axis = 0;
                             }
                             if (name == 'barometer') {
-                                dashStylee = 'ShortDashDot', colorr = '#AA4643', axis = 2;
+                                dashStylee = 'ShortDashDot'; axis = 2;
                             }
                             if (name == 'rain') {
-                                dashStylee = 'solid', axis = 1, colorr = '#4572A7';
+                                dashStylee = 'solid'; axis = 1;
                             }
                             if (name == 'windspeed') {
-                                dashStylee = 'shortDash', colorr = '#bbbbbb', axis = 4,typee = 'spline';
+                                dashStylee = 'shortDash'; axis = 4; typee = 'spline';
                             }
-
 
                             seriesOptions[i] = {
                                 type: typee,
                                 name: name,
                                 yAxis: axis,
-                                color: colorr,
                                 dashStyle: dashStylee,
                                 data: data,
                                 animation: {
@@ -90,7 +86,6 @@ if(isset($_GET['FULL'])) {
                                 useHTML: true,
                                 crosshairs: {
                                     width: 2,
-                                    color: 'gray',
                                     dashStyle: 'shortdot'
                                 }
                             },
@@ -102,16 +97,10 @@ if(isset($_GET['FULL'])) {
                                     labels: {
                                         formatter: function() {
                                             return this.value + 'C';
-                                        },
-                                        style: {
-                                            color: '#89A54E'
                                         }
                                     },
                                     title: {
-                                        text: 'Temperature',
-                                        style: {
-                                            color: '#89A54E'
-                                        }
+                                        text: 'Temperature'
                                     },
                                     opposite: false
 
@@ -119,52 +108,34 @@ if(isset($_GET['FULL'])) {
                                     gridLineWidth: 1,
                                     title: {
                                         text: 'Rainfall',
-                                        type: 'column',
-                                        style: {
-                                            color: '#4572A7'
-                                        }
+                                        type: 'column'
                                     },
                                     labels: {
                                         formatter: function() {
                                             return this.value + ' mm';
-                                        },
-                                        style: {
-                                            color: '#4572A7'
                                         }
                                     }
 
                                 }, {// Tertiary yAxis
                                     gridLineWidth: 2,
                                     title: {
-                                        text: 'Sea-Level Pressure',
-                                        style: {
-                                            color: '#AA4643'
-                                        }
+                                        text: 'Sea-Level Pressure'
                                     },
                                     labels: {
                                         formatter: function() {
                                             return this.value + ' mb';
-                                        },
-                                        style: {
-                                            color: '#AA4643'
                                         }
                                     },
                                     opposite: true
                                 }, {// qrt yAxis
                                     gridLineWidth: 1,
                                     title: {
-                                        text: 'Humidity',
-                                        style: {
-                                            color: '#DDA54E'
-                                        }
+                                        text: 'Humidity'
 
                                     },
                                     labels: {
                                         formatter: function() {
                                             return this.value + ' %';
-                                        },
-                                        style: {
-                                            color: '#DDA54E'
                                         }
 
                                     },
@@ -172,17 +143,11 @@ if(isset($_GET['FULL'])) {
                                 }, {// last yAxis
                                     gridLineWidth: 1,
                                     title: {
-                                        text: 'Wind Speed',
-                                        style: {
-                                            color: '#BBBBBB'
-                                        }
+                                        text: 'Wind Speed'
                                     },
                                     labels: {
                                         formatter: function() {
                                             return this.value + ' mph';
-                                        },
-                                        style: {
-                                            color: '#BBBBBB'
                                         }
                                     },
                                     opposite: true

--- a/newgraph.php
+++ b/newgraph.php
@@ -28,68 +28,57 @@ switch ($what) {
         $gscale = "mm";
         $calc = "SUM";
         $units = 10;
-        $color = "'blue'";
         break;
     case "inTemp":
         $gt = "areaspline";
         $gscale = "°C";
         $units = 1;
-        $color = "Highcharts.getOptions().colors[5]";
         break;
     case "outTemp":
         $gt = "areaspline";
         $gscale = "°C";
         $units = 1;
-        $color = "Highcharts.getOptions().colors[5]";
         break;
     case "barometer":
         $gt = "areaspline";
         $gscale = "mPh";
         $units = 1;
-        $color = "Highcharts.getOptions().colors[5]";
         break;
 
     case "outHumidity":
         $gt = "spline";
         $gscale = "%";
         $units = 1;
-        $color = "Highcharts.getOptions().colors[5]";
         break;
     case "inHumidity":
         $gt = "areaspline";
         $gscale = "%";
         $units = 1;
-        $color = "Highcharts.getOptions().colors[5]";
         break;
     case "windSpeed":
         $gt = "spline";
         $gscale = "m/s";
         $units = 1;
-        $color = "Highcharts.getOptions().colors[5]";
         break;
     case "windGust":
         $gt = "spline";
         $gscale = "m/s";
         $units = 1;
-        $color = "Highcharts.getOptions().colors[5]";
         break;
     case "windDir":
         $gt = "scatter";
         $gscale = "deg";
         $units = 1;
-        $color = "Highcharts.getOptions().colors[5]";
         break;
     case "windGustDir":
         $gt = "scatter";
         $gscale = "deg";
         $units = 1;
-        $color = "Highcharts.getOptions().colors[5]";
         break;
     default:
         $gt = "spline";
         $calc = "AVG";
         $units = 1;
-        $color = "Highcharts.getOptions().colors[5]";
 }
 
 
@@ -187,7 +176,7 @@ switch ($type) {
         }
 
 
-        minmaxgraph($gt, $what, $graphrangedata, $graphaveragedata, $gscale, $scale, $xscale, $color);
+        minmaxgraph($gt, $what, $graphrangedata, $graphaveragedata, $gscale, $scale, $xscale);
         mysqli_free_result($result);
         mysqli_stmt_close($stmt);
         break;
@@ -224,7 +213,7 @@ switch ($type) {
         if (array_key_exists($what, $conditions)) {
             $what = $conditions[$what];
         }
-        standardgraph($gt, $what, $graphdata, $gscale, $scale, $color);
+        standardgraph($gt, $what, $graphdata, $gscale, $scale);
         mysqli_free_result($result);
         mysqli_stmt_close($stmt);
 }
@@ -236,7 +225,7 @@ if (array_key_exists($what, $conditions)) {
 }
 
 
-function minmaxgraph($gt, $what, $graphrangedata, $graphaveragedata, $gscale, $scale, $xscale, $color)
+function minmaxgraph($gt, $what, $graphrangedata, $graphaveragedata, $gscale, $scale, $xscale)
 {
    
     echo "  <div class=\"container-fluid\"><br>
@@ -342,20 +331,15 @@ function minmaxgraph($gt, $what, $graphrangedata, $graphaveragedata, $gscale, $s
         name: '$what',
         data: averages,
         type: '$gt',
-        negativeColor: 'darkblue',
-        threshold: 0,
-        lineWidth: 4,
         zIndex: 1,
-        lineColor: $color,
-        color: $color,
+        lineWidth: 4,
         tooltip: {
             valueSuffix: ' $gscale'
         },
         marker: {
             fillColor: 'white',
             lineWidth: 1,
-            radius: 2,
-            lineColor: Highcharts.getOptions().colors[1]
+            radius: 2
                 }
     }, {
         name: '$what Range',
@@ -363,9 +347,6 @@ function minmaxgraph($gt, $what, $graphrangedata, $graphaveragedata, $gscale, $s
         type: 'columnrange',
         lineWidth: 0,
         linkedTo: ':previous',
-        color: $color,
-        negativeColor: $color,
-        threshold: 0,
         fillOpacity: 0.1,
         zIndex: 10,
         tooltip: {
@@ -386,7 +367,7 @@ function minmaxgraph($gt, $what, $graphrangedata, $graphaveragedata, $gscale, $s
 ";
 }
 
-function standardgraph($gt, $what, $graphdata, $gscale, $scale, $color)
+function standardgraph($gt, $what, $graphdata, $gscale, $scale)
 {
     echo "
     <div class=\"container-fluid\"><br>
@@ -491,7 +472,7 @@ function standardgraph($gt, $what, $graphdata, $gscale, $scale, $color)
                        radius: 0
                    },
                    lineWidth: 1,
-                   lineColor: 'red',
+                   
                    states: {
                        hover: {
                            lineWidth: 1
@@ -502,8 +483,6 @@ function standardgraph($gt, $what, $graphdata, $gscale, $scale, $color)
 
 
          series: {
-           color: $color,
-           negativeColor: 'blue',
            threshold: 0
          }
      },


### PR DESCRIPTION
## Summary
- remove hard-coded colors from graph endpoints
- rely on Highcharts default palette for series and axes

## Testing
- `php -l graph.php`
- `php -l graph2.php`
- `php -l graph3.php`
- `php -l newgraph.php`


------
https://chatgpt.com/codex/tasks/task_e_68b005d46428832e96e44f8d11d0c9f9