### PR TITLE
Replace deprecated error call and remove trailing PHP tags

### DIFF
--- a/astro/moon-phase.cls.php
+++ b/astro/moon-phase.cls.php
@@ -258,4 +258,3 @@ function setDate($timeStamp = -1) {
 
 } // END class moonPhase {
 
-?>

--- a/backend/getdata.php
+++ b/backend/getdata.php
@@ -38,5 +38,4 @@ if (! $link2) {
 }
 
 db_query($SQL, $link2);
-?>
 

--- a/backend/getgraphdata.php
+++ b/backend/getgraphdata.php
@@ -170,4 +170,4 @@ $item = $allowedItems[$itemKey];
 
   mysqli_free_result($result);
  mysqli_stmt_close($stmt);
-?>
+

--- a/backend/getgraphdata2.php
+++ b/backend/getgraphdata2.php
@@ -110,4 +110,4 @@ echo "/* console.log(' sql=$sql,range= $range ,start = $start, end = $end, start
 echo $callback . "([\n" . join(",\n", $rows) . "\n]);";
   mysqli_free_result($result);
  mysqli_stmt_close($stmt);
-?>
+

--- a/backend/multidata.php
+++ b/backend/multidata.php
@@ -169,9 +169,8 @@ $result = mysqli_stmt_get_result($stmt);
 
  // Removed debug comment to ensure valid JSON responses
  if ($isJsonp) {
-   echo $callback . "([\n" . join(",\n", $rows) . "\n]);";
- } else {
-   echo "[\n" . join(",\n", $rows) . "\n]";
+ echo $callback . "([\n" . join(",\n", $rows) . "\n]);";
+  } else {
+  echo "[\n" . join(",\n", $rows) . "\n]";
  }
 
-?>

--- a/backend/schedule.php
+++ b/backend/schedule.php
@@ -17,4 +17,4 @@ echo "..2..";
  db_query('call weather.fill_cubes_min_max_1m();');
 
  echo "Done";
- ?>
+

--- a/backend/winddata.php
+++ b/backend/winddata.php
@@ -25,4 +25,4 @@ header('Content-Type: text/javascript');
 
 echo "/* console.log(' sql=$sql '); */\n";
 echo $callback . "([\n" . join(",\n", $rows) . "\n]);";
-?>
+

--- a/css/index.php
+++ b/css/index.php
@@ -1213,16 +1213,16 @@ if (isset($item))
          }
      }
 
- function calculateMoonPhase($date)
-     {
-     // Date must be timestamp for now
-     if (!is_int($date))
-         {
-         return Services_Weather::raiseError(SERVICES_WEATHER_ERROR_MOONFUNCS_DATE_INVALID,
-                                             __FILE__, __LINE__);
-         }
+function calculateMoonPhase($date)
+    {
+    // Date must be timestamp for now
+    if (!is_int($date))
+        {
+        trigger_error('Invalid date supplied to calculateMoonPhase', E_USER_WARNING);
+        return false;
+        }
 
-     $moon = array();
+    $moon = array();
 
      $year  = date("Y", $date);
      $month = date("n", $date);
@@ -1386,4 +1386,3 @@ if (isset($item))
      return $moon;
      }
 
-?>

--- a/dbconn.php
+++ b/dbconn.php
@@ -32,4 +32,4 @@ function db_query(string $sql, $conn = null)
   }
   return $result;
 }
-?>
+


### PR DESCRIPTION
## Summary
- replace call to non-existent `Services_Weather::raiseError` with a local warning in the moon phase helper
- drop trailing `?>` tags from backend and support scripts to prevent stray output

## Testing
- `php -l css/index.php`
- `php -l dbconn.php`
- `php -l backend/getdata.php`
- `php -l backend/getgraphdata.php`
- `php -l backend/getgraphdata2.php`
- `php -l backend/multidata.php`
- `php -l backend/schedule.php`
- `php -l backend/winddata.php`
- `php -l astro/moon-phase.cls.php`


------
https://chatgpt.com/codex/tasks/task_e_68b015b133fc832eb8141efdf9db2c71