### PR TITLE
Eliminate trailing whitespace in PHP templates

### DIFF
--- a/frontend/picture.php
+++ b/frontend/picture.php
@@ -12,5 +12,4 @@ include('header.php');
     <img src="/snap.jpeg?<?php echo time(); ?>" alt="Latest webcam snapshot" class="w-full h-auto rounded">
   </div>
 </div>
-<?php include('footer.php'); ?>
-
+<?php include('footer.php');

--- a/frontend/reportrainyeartotals.php
+++ b/frontend/reportrainyeartotals.php
@@ -140,5 +140,3 @@ echo "        </table>\n";
 echo "    </div>\n";
 echo "  </div>\n";
 echo "</div>\n";
-?>
-

--- a/frontend/reporttempyeartotals.php
+++ b/frontend/reporttempyeartotals.php
@@ -142,5 +142,3 @@ echo "        </table>\n";
 echo "    </div>\n";
 echo "  </div>\n";
 echo "</div>\n";
-?>
-


### PR DESCRIPTION
## Summary
- Remove closing PHP tags at file ends to avoid accidental whitespace output
- Clean up `picture.php`, `reportrainyeartotals.php`, and `reporttempyeartotals.php`

## Testing
- `php -l frontend/picture.php`
- `php -l frontend/reportrainyeartotals.php`
- `php -l frontend/reporttempyeartotals.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0172948f4832eb4dec3ca152e68e1