### PR TITLE
Simplify table styling

### DIFF
--- a/astro/index.php
+++ b/astro/index.php
@@ -35,9 +35,9 @@ if ($value < 10 ) {$color="green-500";}
 return $color;
 }
 function centrag($value){
-if ($value > 30) {$color="<td class=\\\"px-4 py-2 border-b border-gray-300 border-l-4 border-red-500\\\">$value</td>";}
-if ($value >= 9 && $value <= 30 ) {$color="<td class=\\\"px-4 py-2 border-b border-gray-300 border-l-4 border-yellow-500\\\">$value</td>";}
-if ($value < 10 ) {$color="<td class=\\\"px-4 py-2 border-b border-gray-300 border-l-4 border-green-500\\\">$value</td>";}
+if ($value > 30) {$color="<td class=\\\"px-4 py-2 border-l-4 border-red-500\\\">$value</td>";}
+if ($value >= 9 && $value <= 30 ) {$color="<td class=\\\"px-4 py-2 border-l-4 border-yellow-500\\\">$value</td>";}
+if ($value < 10 ) {$color="<td class=\\\"px-4 py-2 border-l-4 border-green-500\\\">$value</td>";}
 return $color;
 }
 function seeingrag($value){
@@ -54,16 +54,16 @@ function seeingrag($value){
 }
 
 function tenrag($value){
-if ($value > 6) {$color="<td class=\\\"px-4 py-2 border-b border-gray-300 border-l-4 border-green-500 text-green-600\\\"><span class=text-sm>$value</span></td>";}
-if ($value <= 6 && $value >= 4 ) {$color="<td class=\\\"px-4 py-2 border-b border-gray-300 border-l-4 border-yellow-500\\\">$value</td>";}
-if ($value < 4 ) {$color="<td class=\\\"px-4 py-2 border-b border-gray-300 border-l-4 border-red-500\\\">$value</td>";}
+if ($value > 6) {$color="<td class=\\\"px-4 py-2 border-l-4 border-green-500 text-green-600\\\"><span class=text-sm>$value</span></td>";}
+if ($value <= 6 && $value >= 4 ) {$color="<td class=\\\"px-4 py-2 border-l-4 border-yellow-500\\\">$value</td>";}
+if ($value < 4 ) {$color="<td class=\\\"px-4 py-2 border-l-4 border-red-500\\\">$value</td>";}
 return $color;
 }
 
 function thirtyrag($value){
-if ($value > 18) {$color="<td class=\\\"px-4 py-2 border-b border-gray-300 border-l-4 border-green-500 text-green-600\\\"><span class=text-sm>$value</span></td>";}
-if ($value <= 18 && $value >= 4 ) {$color="<td class=\\\"px-4 py-2 border-b border-gray-300 border-l-4 border-yellow-500\\\">$value</td>";}
-if ($value < 12 ) {$color="<td class=\\\"px-4 py-2 border-b border-gray-300 border-l-4 border-red-500\\\">$value</td>";}
+if ($value > 18) {$color="<td class=\\\"px-4 py-2 border-l-4 border-green-500 text-green-600\\\"><span class=text-sm>$value</span></td>";}
+if ($value <= 18 && $value >= 4 ) {$color="<td class=\\\"px-4 py-2 border-l-4 border-yellow-500\\\">$value</td>";}
+if ($value < 12 ) {$color="<td class=\\\"px-4 py-2 border-l-4 border-red-500\\\">$value</td>";}
 return $color;
 }
 
@@ -87,7 +87,7 @@ function getdetail($date,$json) {
   foreach ($json['metcheckData']['forecastLocation']['forecast'] as $key=>$value) {
 
     $hourrag=seeingrag($json['metcheckData']['forecastLocation']['forecast'][$key]['seeingIndex']);
-    $html.="<tr class=\\\"border-l-4 $hourrag hover:bg-gray-100 odd:bg-gray-50\\\">";
+    $html.="<tr class=\\\"border-l-4 $hourrag\\\">";
     $detaildate=$json['metcheckData']['forecastLocation']['forecast'][$key]['utcTime'];
     $nicedate = date('l', strtotime(substr($detaildate,0,10))).' '.substr($detaildate,11,5);
   if ($date==substr($detaildate,0,10)) {

--- a/frontend/extremes.php
+++ b/frontend/extremes.php
@@ -43,13 +43,13 @@ require_once '../dbconn.php';
               <th class="px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Min</th>
             </tr>
           </thead>
-          <tbody>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Outside Temp</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $day['outTempMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $day['outTempMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Inside Temp</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $day['inTempMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $day['inTempMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Inside Humidity</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $day['inHumMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $day['inHumMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Outside Humidity</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $day['outHumMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $day['outHumMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Pressure</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $day['baroMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $day['baroMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Rain (total)</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $day['rainTotal']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right">0</td></tr>
+          <tbody class="divide-y divide-gray-200">
+            <tr><td class="px-4 py-2 text-left">Outside Temp</td><td class="px-4 py-2 text-right"><?php echo $day['outTempMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $day['outTempMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Inside Temp</td><td class="px-4 py-2 text-right"><?php echo $day['inTempMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $day['inTempMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Inside Humidity</td><td class="px-4 py-2 text-right"><?php echo $day['inHumMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $day['inHumMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Outside Humidity</td><td class="px-4 py-2 text-right"><?php echo $day['outHumMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $day['outHumMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Pressure</td><td class="px-4 py-2 text-right"><?php echo $day['baroMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $day['baroMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Rain (total)</td><td class="px-4 py-2 text-right"><?php echo $day['rainTotal']; ?></td><td class="px-4 py-2 text-right">0</td></tr>
           </tbody>
         </table><!-- Last 24 Hours table -->
       </div>
@@ -69,13 +69,13 @@ require_once '../dbconn.php';
               <th class="px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Min</th>
             </tr>
           </thead>
-          <tbody>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Outside Temp</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $week['outTempMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $week['outTempMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Inside Temp</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $week['inTempMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $week['inTempMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Inside Humidity</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $week['inHumMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $week['inHumMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Outside Humidity</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $week['outHumMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $week['outHumMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Pressure</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $week['baroMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $week['baroMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Rain (total)</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $week['rainTotal']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right">0</td></tr>
+          <tbody class="divide-y divide-gray-200">
+            <tr><td class="px-4 py-2 text-left">Outside Temp</td><td class="px-4 py-2 text-right"><?php echo $week['outTempMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $week['outTempMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Inside Temp</td><td class="px-4 py-2 text-right"><?php echo $week['inTempMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $week['inTempMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Inside Humidity</td><td class="px-4 py-2 text-right"><?php echo $week['inHumMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $week['inHumMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Outside Humidity</td><td class="px-4 py-2 text-right"><?php echo $week['outHumMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $week['outHumMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Pressure</td><td class="px-4 py-2 text-right"><?php echo $week['baroMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $week['baroMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Rain (total)</td><td class="px-4 py-2 text-right"><?php echo $week['rainTotal']; ?></td><td class="px-4 py-2 text-right">0</td></tr>
           </tbody>
         </table><!-- Last 7 Days table -->
       </div>
@@ -95,13 +95,13 @@ require_once '../dbconn.php';
               <th class="px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Min</th>
             </tr>
           </thead>
-          <tbody>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Outside Temp</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $month['outTempMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $month['outTempMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Inside Temp</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $month['inTempMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $month['inTempMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Inside Humidity</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $month['inHumMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $month['inHumMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Outside Humidity</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $month['outHumMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $month['outHumMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Pressure</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $month['baroMax']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $month['baroMin']; ?></td></tr>
-            <tr class="hover:bg-gray-100 odd:bg-gray-50"><td class="px-4 py-2 border-b border-gray-300 text-left">Rain (total)</td><td class="px-4 py-2 border-b border-gray-300 text-right"><?php echo $month['rainTotal']; ?></td><td class="px-4 py-2 border-b border-gray-300 text-right">0</td></tr>
+          <tbody class="divide-y divide-gray-200">
+            <tr><td class="px-4 py-2 text-left">Outside Temp</td><td class="px-4 py-2 text-right"><?php echo $month['outTempMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $month['outTempMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Inside Temp</td><td class="px-4 py-2 text-right"><?php echo $month['inTempMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $month['inTempMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Inside Humidity</td><td class="px-4 py-2 text-right"><?php echo $month['inHumMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $month['inHumMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Outside Humidity</td><td class="px-4 py-2 text-right"><?php echo $month['outHumMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $month['outHumMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Pressure</td><td class="px-4 py-2 text-right"><?php echo $month['baroMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $month['baroMin']; ?></td></tr>
+            <tr><td class="px-4 py-2 text-left">Rain (total)</td><td class="px-4 py-2 text-right"><?php echo $month['rainTotal']; ?></td><td class="px-4 py-2 text-right">0</td></tr>
           </tbody>
         </table><!-- Last Month table -->
       </div>

--- a/frontend/forecast.php
+++ b/frontend/forecast.php
@@ -235,7 +235,7 @@ Meteogram.prototype.tooltipFormatter = function (tooltip) {
     // Symbol text
     ret += '<b>' + this.symbolNames[index] + '</b>';
 
-    ret += '<table>';
+    ret += '<table class="bg-white divide-y divide-gray-200">';
 
     // Add all series
     Highcharts.each(tooltip.points, function (point) {

--- a/frontend/report.php
+++ b/frontend/report.php
@@ -98,38 +98,38 @@ echo "    <th class=\"px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-3
 echo "    <th class=\"px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-center text-sm uppercase font-semibold\">0.30</th>\n";
 echo "    <th class=\"px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-center text-sm uppercase font-semibold\">3.00</th>\n";
 echo "  </tr>\n";
-echo "</thead><tbody>";
+echo "</thead><tbody class=\"divide-y divide-gray-200\">";
 
 for ($month = 1; $month <= 12; $month++) {
     if (isset($monthly_data[$month])) {
         $data = $monthly_data[$month];
-        echo "<tr class=\"hover:bg-gray-100 odd:bg-gray-50\">";
-        echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-left\">{$data['year']}</td>";
-        echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-left\">" . str_pad($data['month'], 2, '0', STR_PAD_LEFT) . "</td>";
-        echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-right\">{$data['total_precip_cm']}</td>";
-        echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-right\">{$data['max_daily_precip_cm']} ({$data['max_day']})</td>";
-        echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-right\">{$data['days_over_0_03cm']}</td>";
-        echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-right\">{$data['days_over_0_30cm']}</td>";
-        echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-right\">{$data['days_over_3_00cm']}</td>";
+        echo "<tr>";
+        echo "  <td class=\"px-4 py-2 text-left\">{$data['year']}</td>";
+        echo "  <td class=\"px-4 py-2 text-left\">" . str_pad($data['month'], 2, '0', STR_PAD_LEFT) . "</td>";
+        echo "  <td class=\"px-4 py-2 text-right\">{$data['total_precip_cm']}</td>";
+        echo "  <td class=\"px-4 py-2 text-right\">{$data['max_daily_precip_cm']} ({$data['max_day']})</td>";
+        echo "  <td class=\"px-4 py-2 text-right\">{$data['days_over_0_03cm']}</td>";
+        echo "  <td class=\"px-4 py-2 text-right\">{$data['days_over_0_30cm']}</td>";
+        echo "  <td class=\"px-4 py-2 text-right\">{$data['days_over_3_00cm']}</td>";
         echo "</tr>";
     } else {
         // No data for this month
-        echo "<tr class=\"hover:bg-gray-100 odd:bg-gray-50\">";
-        echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-left\">$year</td>";
-        echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-left\">" . str_pad($month, 2, '0', STR_PAD_LEFT) . "</td>";
-        echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-center\" colspan='5'>No Data</td>";
+        echo "<tr>";
+        echo "  <td class=\"px-4 py-2 text-left\">$year</td>";
+        echo "  <td class=\"px-4 py-2 text-left\">" . str_pad($month, 2, '0', STR_PAD_LEFT) . "</td>";
+        echo "  <td class=\"px-4 py-2 text-center\" colspan='5'>No Data</td>";
         echo "</tr>";
     }
 }
 
 // Display totals
-echo "<tr class=\"bg-gray-200 font-bold\">";
-echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-left\" colspan='2'>Totals</td>";
-echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-right\">{$totals['total_precip_cm']}</td>";
-echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-right\">{$totals['max_daily_precip_cm']} ({$totals['max_month']})</td>";
-echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-right\">{$totals['days_over_0_03cm']}</td>";
-echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-right\">{$totals['days_over_0_30cm']}</td>";
-echo "  <td class=\"px-4 py-2 border-b border-gray-300 text-right\">{$totals['days_over_3_00cm']}</td>";
+echo "<tr class=\"font-bold\">";
+echo "  <td class=\"px-4 py-2 text-left\" colspan='2'>Totals</td>";
+echo "  <td class=\"px-4 py-2 text-right\">{$totals['total_precip_cm']}</td>";
+echo "  <td class=\"px-4 py-2 text-right\">{$totals['max_daily_precip_cm']} ({$totals['max_month']})</td>";
+echo "  <td class=\"px-4 py-2 text-right\">{$totals['days_over_0_03cm']}</td>";
+echo "  <td class=\"px-4 py-2 text-right\">{$totals['days_over_0_30cm']}</td>";
+echo "  <td class=\"px-4 py-2 text-right\">{$totals['days_over_3_00cm']}</td>";
 echo "</tr>";
 
 echo "</tbody></table>";

--- a/frontend/reportrainyeartotals.php
+++ b/frontend/reportrainyeartotals.php
@@ -92,20 +92,20 @@ foreach ($years as $year) {
     echo "            <th class=\"px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold\">$year</th>";
 }
 
-echo "          </tr>\n          </thead>\n          <tbody>";
+echo "          </tr>\n          </thead>\n          <tbody class=\"divide-y divide-gray-200\">";
 
 // Table rows for each month
 foreach ($months as $month) {
-    echo "          <tr class=\"hover:bg-gray-100 odd:bg-gray-50\">";
+    echo "          <tr>";
     // Display the month name
     $month_name = date('F', mktime(0, 0, 0, $month, 10));
-    echo "            <td class=\"px-4 py-2 border-b border-gray-300 text-left\">$month_name</td>";
+    echo "            <td class=\"px-4 py-2 text-left\">$month_name</td>";
 
     // Display rainfall data for each year
     foreach ($years as $year) {
         if (isset($rainfall_data[$year][$month])) {
             $rain_mm = $rainfall_data[$year][$month];
-            $cell_class = "px-4 py-2 border-b border-gray-300 text-right";
+            $cell_class = "px-4 py-2 text-right";
 
             $border_style = "";
             if (in_array($year, $years_with_max_rainfall[$month])) {
@@ -117,7 +117,7 @@ foreach ($months as $month) {
             $style_attr = $border_style ? " style=\\\"$border_style\\\"" : "";
             echo "            <td class=\"$cell_class\"$style_attr>$rain_mm</td>";
         } else {
-            echo "            <td class=\"px-4 py-2 border-b border-gray-300 text-right\">0</td>"; // No data for this month and year
+            echo "            <td class=\"px-4 py-2 text-right\">0</td>"; // No data for this month and year
         }
     }
 
@@ -125,12 +125,12 @@ foreach ($months as $month) {
 }
 
 // Add the total row
-echo "          <tr class=\"bg-gray-200 font-bold\">";
-echo "            <td class=\"px-4 py-2 border-b border-gray-300 text-left\">Total</td>";
+echo "          <tr class=\"font-bold\">";
+echo "            <td class=\"px-4 py-2 text-left\">Total</td>";
 
 foreach ($years as $year) {
     $total_rain_mm = isset($total_rainfall_per_year[$year]) ? $total_rainfall_per_year[$year] : 0;
-    echo "            <td class=\"px-4 py-2 border-b border-gray-300 text-right\">$total_rain_mm</td>";
+    echo "            <td class=\"px-4 py-2 text-right\">$total_rain_mm</td>";
 }
 
 echo "          </tr>";

--- a/frontend/reporttempyeartotals.php
+++ b/frontend/reporttempyeartotals.php
@@ -84,24 +84,24 @@ echo "            <th class=\"px-4 py-2 bg-gray-200 text-gray-600 border-b borde
 
 // Header cells for each year
 foreach ($years as $year) {
-  echo '            <th class="px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-center text-sm uppercase font-semibold" colspan="3">' . $year . '</th>';
+  echo '            <th class="px-4 py-2 bg-gray-200 text-gray-600 text-center text-sm uppercase font-semibold" colspan="3">' . $year . '</th>';
 }
 
 echo "          </tr>\n";
 echo "          <tr>";
 foreach ($years as $year) {
-  echo '            <th class="px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-center text-sm uppercase font-semibold">Avg</th>' .
-       '<th class="px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-center text-sm uppercase font-semibold">Max</th>' .
-       '<th class="px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-center text-sm uppercase font-semibold">Min</th>';
+  echo '            <th class="px-4 py-2 bg-gray-200 text-gray-600 text-center text-sm uppercase font-semibold">Avg</th>' .
+       '<th class="px-4 py-2 bg-gray-200 text-gray-600 text-center text-sm uppercase font-semibold">Max</th>' .
+       '<th class="px-4 py-2 bg-gray-200 text-gray-600 text-center text-sm uppercase font-semibold">Min</th>';
 }
-echo "          </tr>\n          </thead>\n          <tbody>";
+echo "          </tr>\n          </thead>\n          <tbody class=\"divide-y divide-gray-200\">";
 
 // Table rows for each month
 foreach ($months as $month) {
-  echo "          <tr class=\"hover:bg-gray-100 odd:bg-gray-50\">";
+  echo "          <tr>";
   // Display the month name
   $month_name = date('F', mktime(0, 0, 0, $month, 10));
-  echo "            <td class=\"px-4 py-2 border-b border-gray-300 text-left\">$month_name</td>";
+  echo "            <td class=\"px-4 py-2 text-left\">$month_name</td>";
 
   // Display temperature data for each year
   foreach ($years as $year) {
@@ -111,9 +111,9 @@ foreach ($months as $month) {
         $max_temp = $data['max_temp'];
         $min_temp = $data['min_temp'];
 
-        $avg_class = "px-4 py-2 border-b border-gray-300 text-right";
-        $max_class = "px-4 py-2 border-b border-gray-300 text-right";
-        $min_class = "px-4 py-2 border-b border-gray-300 text-right";
+        $avg_class = "px-4 py-2 text-right";
+        $max_class = "px-4 py-2 text-right";
+        $min_class = "px-4 py-2 text-right";
 
         if (isset($years_with_max_temp[$month]) && in_array($year, $years_with_max_temp[$month])) {
           $max_class .= " text-red-500";
@@ -128,9 +128,9 @@ foreach ($months as $month) {
         echo "            <td class=\\\"$min_class\\\">$min_temp</td>";
     } else {
         // No data for this month and year
-        echo "            <td class=\\\"px-4 py-2 border-b border-gray-300 text-right\\\">-</td>";
-        echo "            <td class=\\\"px-4 py-2 border-b border-gray-300 text-right\\\">-</td>";
-        echo "            <td class=\\\"px-4 py-2 border-b border-gray-300 text-right\\\">-</td>";
+        echo "            <td class=\\\"px-4 py-2 text-right\\\">-</td>";
+        echo "            <td class=\\\"px-4 py-2 text-right\\\">-</td>";
+        echo "            <td class=\\\"px-4 py-2 text-right\\\">-</td>";
     }
   }
 

--- a/frontend/reportwindyeartotals.php
+++ b/frontend/reportwindyeartotals.php
@@ -115,26 +115,26 @@ echo "          <tr>\n";
 echo "            <th class=\"px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-left text-sm uppercase font-semibold\" rowspan=\"2\">Month</th>";
 
 foreach ($years as $year) {
-  echo '            <th class="px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-center text-sm uppercase font-semibold" colspan="3">' . $year . '</th>';
+  echo '            <th class="px-4 py-2 bg-gray-200 text-gray-600 text-center text-sm uppercase font-semibold" colspan="3">' . $year . '</th>';
 }
 
 echo "          </tr>\n";
 echo "          <tr>";
 foreach ($years as $year) {
-  echo '            <th class="px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-center text-sm uppercase font-semibold">Avg</th>' .
-       '<th class="px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-center text-sm uppercase font-semibold">Max</th>' .
-       '<th class="px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-center text-sm uppercase font-semibold">Dir</th>';
+  echo '            <th class="px-4 py-2 bg-gray-200 text-gray-600 text-center text-sm uppercase font-semibold">Avg</th>' .
+       '<th class="px-4 py-2 bg-gray-200 text-gray-600 text-center text-sm uppercase font-semibold">Max</th>' .
+       '<th class="px-4 py-2 bg-gray-200 text-gray-600 text-center text-sm uppercase font-semibold">Dir</th>';
 }
 echo "          </tr>\n";
 echo "          </thead>\n";
-echo "          <tbody>\n";
+echo "          <tbody class=\"divide-y divide-gray-200\">\n";
 
 // Table rows for each month
 foreach ($months as $month) {
-    echo "          <tr class=\"hover:bg-gray-100 odd:bg-gray-50\">";
+    echo "          <tr>";
     // Display the month name
     $month_name = date('F', mktime(0, 0, 0, $month, 10));
-    echo "            <td class=\"px-4 py-2 border-b border-gray-300 text-left\">$month_name</td>";
+    echo "            <td class=\"px-4 py-2 text-left\">$month_name</td>";
 
     // Display wind data for each year
     foreach ($years as $year) {
@@ -144,7 +144,7 @@ foreach ($months as $month) {
             $max_wind_gust = number_format($data['max_wind_gust'], 1);
             $max_wind_dir = $data['max_wind_dir'];
 
-            $avg_class = "px-4 py-2 border-b border-gray-300 text-right";
+            $avg_class = "px-4 py-2 text-right";
             if (isset($years_with_max_avg[$month]) && in_array($year, $years_with_max_avg[$month])) {
                 $avg_class .= " text-red-500";
             }
@@ -152,7 +152,7 @@ foreach ($months as $month) {
                 $avg_class .= " text-blue-500";
             }
 
-            $gust_class = "px-4 py-2 border-b border-gray-300 text-right";
+            $gust_class = "px-4 py-2 text-right";
             if (isset($years_with_max_gust[$month]) && in_array($year, $years_with_max_gust[$month])) {
                 $gust_class .= " text-red-500";
             }
@@ -162,12 +162,12 @@ foreach ($months as $month) {
 
             echo '            <td class="' . $avg_class . '">' . $avg_wind_speed . "</td>";
             echo '            <td class="' . $gust_class . '">' . $max_wind_gust . "</td>";
-            echo '            <td class="px-4 py-2 border-b border-gray-300 text-center">' . $max_wind_dir . "</td>";
+            echo '            <td class="px-4 py-2 text-center">' . $max_wind_dir . "</td>";
         } else {
             // No data for this month and year
-            echo '            <td class="px-4 py-2 border-b border-gray-300 text-right">-</td>' .
-                 '<td class="px-4 py-2 border-b border-gray-300 text-right">-</td>' .
-                 '<td class="px-4 py-2 border-b border-gray-300 text-center">-</td>';
+            echo '            <td class="px-4 py-2 text-right">-</td>' .
+                 '<td class="px-4 py-2 text-right">-</td>' .
+                 '<td class="px-4 py-2 text-center">-</td>';
         }
     }
 

--- a/frontend/windrose.php
+++ b/frontend/windrose.php
@@ -50,7 +50,7 @@ $sql = "SELECT
   echo "<th class=\"px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold\">2–3&nbsp;m/s</th>";
   echo "<th class=\"px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold\">1–2&nbsp;m/s</th>";
   echo "<th class=\"px-4 py-2 bg-gray-200 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold\">0–1&nbsp;m/s</th>";
-  echo "</tr></thead><tbody>";
+  echo "</tr></thead><tbody class=\"divide-y divide-gray-200\">";
 
   $dirs = ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW'];
   $data = array_fill(0, 16, ['A' => 0, 'B' => 0, 'C' => 0, 'D' => 0]);
@@ -64,7 +64,7 @@ $sql = "SELECT
 
   for ($i = 0; $i < 16; $i++) {
     $wind_dir = $dirs[$i];
-    echo "<tr class=\"hover:bg-gray-100 odd:bg-gray-50\"><td class=\"px-4 py-2 border-b border-gray-300 text-left\">$wind_dir</td><td class=\"px-4 py-2 border-b border-gray-300 text-right\">{$data[$i]['D']}</td><td class=\"px-4 py-2 border-b border-gray-300 text-right\">{$data[$i]['C']}</td><td class=\"px-4 py-2 border-b border-gray-300 text-right\">{$data[$i]['B']}</td><td class=\"px-4 py-2 border-b border-gray-300 text-right\">{$data[$i]['A']}</td></tr>";
+    echo "<tr><td class=\"px-4 py-2 text-left\">$wind_dir</td><td class=\"px-4 py-2 text-right\">{$data[$i]['D']}</td><td class=\"px-4 py-2 text-right\">{$data[$i]['C']}</td><td class=\"px-4 py-2 text-right\">{$data[$i]['B']}</td><td class=\"px-4 py-2 text-right\">{$data[$i]['A']}</td></tr>";
   }
 
   echo "</tbody></table></div>";


### PR DESCRIPTION
## Summary
- Remove zebra striping and cell borders from frontend tables for a clean white background
- Use Tailwind `divide-y` utilities to render thin gray lines between table rows
- Apply streamlined table styles across reports, wind rose, extremes, and forecast tooltip

## Testing
- `php -l frontend/extremes.php`
- `php -l frontend/windrose.php`
- `php -l frontend/report.php`
- `php -l frontend/reporttempyeartotals.php`
- `php -l frontend/reportwindyeartotals.php`
- `php -l frontend/reportrainyeartotals.php`
- `php -l frontend/forecast.php`
- `php -l astro/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b017960ef0832e82efec10385acab0