### PR TITLE
Fix temperature table coloring and sidebar icon

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -79,7 +79,7 @@ $minTemp = $row['minTemp'];
     <div class="flex min-h-screen">
       <aside id="sidebar" class="bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 w-64 space-y-2 py-4 px-2 absolute inset-y-0 left-0 z-40 transform -translate-x-full md:relative md:translate-x-0 transition duration-200 ease-in-out">
       <a id="navname" class="flex items-center space-x-2 px-4" href="/">
-        <img src="/images/icon.png" class="w-8 h-8" alt="">
+        <img src="../images/icon.png" class="w-8 h-8" alt="Site icon">
         <span>Wheathampstead Weather</span>
       </a>
         <nav class="mt-4">

--- a/frontend/reporttempyeartotals.php
+++ b/frontend/reporttempyeartotals.php
@@ -123,14 +123,14 @@ foreach ($months as $month) {
           $min_class .= " text-blue-500";
         }
 
-        echo "            <td class=\\\"$avg_class\\\">$avg_temp</td>";
-        echo "            <td class=\\\"$max_class\\\">$max_temp</td>";
-        echo "            <td class=\\\"$min_class\\\">$min_temp</td>";
+        echo "            <td class=\"$avg_class\">$avg_temp</td>";
+        echo "            <td class=\"$max_class\">$max_temp</td>";
+        echo "            <td class=\"$min_class\">$min_temp</td>";
     } else {
         // No data for this month and year
-        echo "            <td class=\\\"px-4 py-2 text-right\\\">-</td>";
-        echo "            <td class=\\\"px-4 py-2 text-right\\\">-</td>";
-        echo "            <td class=\\\"px-4 py-2 text-right\\\">-</td>";
+        echo "            <td class=\"px-4 py-2 text-right\">-</td>";
+        echo "            <td class=\"px-4 py-2 text-right\">-</td>";
+        echo "            <td class=\"px-4 py-2 text-right\">-</td>";
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix class attribute generation so monthly max/min cells show red and blue highlighting in temperature-by-year report
- Point sidebar logo to existing `images/icon.png` and provide descriptive alt text

## Testing
- `php -l frontend/reporttempyeartotals.php`
- `php -l frontend/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0242ccb74832ea063a31272ba7df8