### PR TITLE
fix backend fetch paths after moving webroot

### DIFF
--- a/frontend/metric-graph.php
+++ b/frontend/metric-graph.php
@@ -66,7 +66,7 @@ $SQLCOLDM = "SELECT round(MIN(`archive`.`$item`),1) FROM `weewx`.`archive` WHERE
 
         document.addEventListener('DOMContentLoaded', function() {
 
-            fetch('https://www.smeird.com/backend/metric-data.php?item=<?php echo $item; ?>')
+            fetch('/backend/metric-data.php?item=<?php echo $item; ?>')
               .then(response => response.json())
               .then(function(data) {
 
@@ -240,7 +240,7 @@ $SQLCOLDM = "SELECT round(MIN(`archive`.`$item`),1) FROM `weewx`.`archive` WHERE
                     range = e.max - e.min;
 
             chart.showLoading('Getting correct data from server...');
-            fetch('https://www.smeird.com/backend/metric-data.php?start=' + Math.round(e.min) +
+            fetch('/backend/metric-data.php?start=' + Math.round(e.min) +
                     '&end=' + Math.round(e.max) + '&item=<?php echo $item; ?>')
               .then(response => response.json())
               .then(function(data) {

--- a/frontend/overview-graph.php
+++ b/frontend/overview-graph.php
@@ -16,7 +16,7 @@ if(isset($_GET['FULL'])) {
                         colors = Highcharts.getOptions().colors;
 
                     names.forEach(function(name, i) {
-                        fetch('../backend/multidata.php?item=' + encodeURIComponent(name.toLowerCase()))
+                        fetch('/backend/multidata.php?item=' + encodeURIComponent(name.toLowerCase()))
                           .then(function(response) {
                             if (!response.ok) {
                               throw new Error('Network response was not ok');

--- a/frontend/range-graph.php
+++ b/frontend/range-graph.php
@@ -14,7 +14,7 @@ if(isset($_GET['FULL'])) {
 <script type='text/javascript'>//<![CDATA[
         document.addEventListener('DOMContentLoaded', function() {
             // See source code from the JSONP handler at https://github.com/highslide-software/highcharts.com/blob/master/samples/data/from-sql.php
-            fetch('https://www.smeird.com/backend/range-data.php?itemmm=<?php echo $itemmm; ?>')
+            fetch('/backend/range-data.php?itemmm=<?php echo $itemmm; ?>')
               .then(response => response.json())
               .then(function(data) {
                 // Add a null value for the end date
@@ -125,7 +125,7 @@ if(isset($_GET['FULL'])) {
                     range = e.max - e.min;
 
             chart.showLoading('Getting correct data from server...');
-            fetch('https://www.smeird.com/backend/range-data.php?start=' + Math.round(e.min) +
+            fetch('/backend/range-data.php?start=' + Math.round(e.min) +
                     '&end=' + Math.round(e.max) + '&itemmm=<?php echo $itemmm; ?>')
               .then(response => response.json())
               .then(function(data) {


### PR DESCRIPTION
## Summary
- adjust JS fetch URLs to point at /backend now that webroot is frontend

## Testing
- `php -l frontend/overview-graph.php`
- `php -l frontend/metric-graph.php`
- `php -l frontend/range-graph.php`


------
https://chatgpt.com/codex/tasks/task_e_68b031ae69c8832ea1f11df5c7d20cac