### PR TITLE
Fix graph and asset paths for subdirectory deployment

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -58,11 +58,11 @@ $minTemp = $row['minTemp'];
   <script src="https://code.highcharts.com/modules/exporting.js"></script>
   <script src="https://code.highcharts.com/modules/solid-gauge.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/canvg/3.0.7/umd.min.js"></script>
-  <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
-  <link rel="manifest" href="/manifest.json">
-  <link rel="mask-icon" href="/images/safari-pinned-tab.svg" color="#5bbad5">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png">
+  <link rel="manifest" href="manifest.json">
+  <link rel="mask-icon" href="images/safari-pinned-tab.svg" color="#5bbad5">
   <meta name="theme-color" content="#ffffff">
   <style>
     body { font-family: 'Inter', sans-serif; }

--- a/frontend/metric-graph.php
+++ b/frontend/metric-graph.php
@@ -66,7 +66,7 @@ $SQLCOLDM = "SELECT round(MIN(`archive`.`$item`),1) FROM `weewx`.`archive` WHERE
 
         document.addEventListener('DOMContentLoaded', function() {
 
-            fetch('/backend/metric-data.php?item=<?php echo $item; ?>')
+            fetch('backend/metric-data.php?item=<?php echo $item; ?>')
               .then(response => response.json())
               .then(function(data) {
 
@@ -240,8 +240,8 @@ $SQLCOLDM = "SELECT round(MIN(`archive`.`$item`),1) FROM `weewx`.`archive` WHERE
                     range = e.max - e.min;
 
             chart.showLoading('Getting correct data from server...');
-            fetch('/backend/metric-data.php?start=' + Math.round(e.min) +
-                    '&end=' + Math.round(e.max) + '&item=<?php echo $item; ?>')
+            fetch('backend/metric-data.php?start=' + Math.round(e.min) +
+                '&end=' + Math.round(e.max) + '&item=<?php echo $item; ?>')
               .then(response => response.json())
               .then(function(data) {
                 chart.series[0].setData(data);

--- a/frontend/overview-graph.php
+++ b/frontend/overview-graph.php
@@ -16,7 +16,7 @@ if(isset($_GET['FULL'])) {
                         colors = Highcharts.getOptions().colors;
 
                     names.forEach(function(name, i) {
-                        fetch('/backend/multidata.php?item=' + encodeURIComponent(name.toLowerCase()))
+                        fetch('backend/multidata.php?item=' + encodeURIComponent(name.toLowerCase()))
                           .then(function(response) {
                             if (!response.ok) {
                               throw new Error('Network response was not ok');

--- a/frontend/range-graph.php
+++ b/frontend/range-graph.php
@@ -14,7 +14,7 @@ if(isset($_GET['FULL'])) {
 <script type='text/javascript'>//<![CDATA[
         document.addEventListener('DOMContentLoaded', function() {
             // See source code from the JSONP handler at https://github.com/highslide-software/highcharts.com/blob/master/samples/data/from-sql.php
-            fetch('/backend/range-data.php?itemmm=<?php echo $itemmm; ?>')
+            fetch('backend/range-data.php?itemmm=<?php echo $itemmm; ?>')
               .then(response => response.json())
               .then(function(data) {
                 // Add a null value for the end date
@@ -125,8 +125,8 @@ if(isset($_GET['FULL'])) {
                     range = e.max - e.min;
 
             chart.showLoading('Getting correct data from server...');
-            fetch('/backend/range-data.php?start=' + Math.round(e.min) +
-                    '&end=' + Math.round(e.max) + '&itemmm=<?php echo $itemmm; ?>')
+            fetch('backend/range-data.php?start=' + Math.round(e.min) +
+                '&end=' + Math.round(e.max) + '&itemmm=<?php echo $itemmm; ?>')
               .then(response => response.json())
               .then(function(data) {
                 chart.series[0].setData(data);


### PR DESCRIPTION
## Summary
- Load manifest and icons via relative links so assets resolve when site lives in a subdirectory
- Fetch graph data using `backend/` relative paths to avoid 404s

## Testing
- `php -l frontend/header.php`
- `php -l frontend/overview-graph.php`
- `php -l frontend/metric-graph.php`
- `php -l frontend/range-graph.php`


------
https://chatgpt.com/codex/tasks/task_e_68b032f8ec74832eaebf6b8b6a6ac3d8