### PR TITLE
Handle null temps in records

### DIFF
--- a/frontend/records.php
+++ b/frontend/records.php
@@ -7,6 +7,8 @@ $SQLHOT = "SELECT
   FROM_UNIXTIME(archive.dateTime, '%Y-%m-%d %H:%i:%s') AS dt
 FROM
   weewx.archive
+WHERE
+  archive.outTemp IS NOT NULL
 ORDER BY
   archive.outTemp DESC
 LIMIT 1";
@@ -16,6 +18,8 @@ $SQLCOLD = "SELECT
   FROM_UNIXTIME(archive.dateTime, '%Y-%m-%d %H:%i:%s') AS dt
 FROM
   weewx.archive
+WHERE
+  archive.outTemp IS NOT NULL
 ORDER BY
   archive.outTemp ASC
 LIMIT 1";


### PR DESCRIPTION
## Summary
- ignore null temperature rows when finding hottest and coldest days

## Testing
- `php -l frontend/records.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0390e9148832ea43c45a89a720ca6