### PR TITLE
Fix astro page include paths

### DIFF
--- a/frontend/astro/index.php
+++ b/frontend/astro/index.php
@@ -1,8 +1,8 @@
 <?php
- include ('../header.php');
- include ('moon.php');
+include __DIR__ . '/../header.php';
+include __DIR__ . '/moon.php';
 
- $singledate = $_GET['DATE'];
+$singledate = $_GET['DATE'];
 $detailcolor = $_GET['DATECOLOR'];
 ?>
 

--- a/frontend/header.php
+++ b/frontend/header.php
@@ -4,7 +4,7 @@
 date_default_timezone_set("Europe/London");
 setlocale(LC_ALL, 'uk_UA.utf8');
 
-require_once '../dbconn.php';
+require_once __DIR__ . '/../dbconn.php';
 $sql = "
     SELECT
         round(`archive`.`outTemp`,1) AS `outTemp`,
@@ -94,7 +94,7 @@ $minTemp = $row['minTemp'];
           <a class="block py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="http://ob.smeird.com">Sky Weather</a>
           <a class="block py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="http://power.smeird.com">Power Use</a>
           <a class="block py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="index.php"><span id="connect">Not Connected</span></a>
-        <?php include('graph-selector.php'); ?>
+        <?php include __DIR__ . '/graph-selector.php'; ?>
       </nav>
     </aside>
     <script>


### PR DESCRIPTION
## Summary
- fix header include paths so astro pages can find db connection and graph selector
- reference astro resources via `__DIR__` for reliable includes

## Testing
- `php -l frontend/header.php`
- `php -l frontend/astro/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b03a1e43b8832e9f63ed78025379b7