### PR TITLE
Relocate live status and show connected/disconnected icons

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -81,6 +81,9 @@ $minTemp = $row['minTemp'];
         <img src="/images/icon.png" class="w-8 h-8" alt="Site icon">
         <span>Wheathampstead Weather</span>
       </a>
+      <div id="connect" class="flex items-center px-4 mt-2 text-red-500">
+        <i class="fas fa-circle mr-2"></i>Disconnected
+      </div>
         <nav class="mt-4">
           <a class="block py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/">Home <span class="sr-only">(current)</span></a>
           <a class="block py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/extremes.php">Extremes</a>
@@ -93,10 +96,9 @@ $minTemp = $row['minTemp'];
           <a class="block py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/astro">Astro</a>
           <a class="block py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="http://ob.smeird.com">Sky Weather</a>
           <a class="block py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="http://power.smeird.com">Power Use</a>
-          <a class="block py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="index.php"><span id="connect">Not Connected</span></a>
-        <?php include('graph-selector.php'); ?>
-      </nav>
-    </aside>
+          <?php include('graph-selector.php'); ?>
+        </nav>
+      </aside>
     <script>
       document.getElementById('sidebar-toggle').addEventListener('click', function() {
         document.getElementById('sidebar').classList.toggle('-translate-x-full');

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -162,8 +162,9 @@ require_once '../dbconn.php';
 
     // connect the client
     client.connect({
-        useSSL: true,
-        onSuccess: onConnect
+      useSSL: true,
+      onSuccess: onConnect,
+      onFailure: onFailure
     });
 
     function uuidv4() {
@@ -179,14 +180,19 @@ require_once '../dbconn.php';
       // Once a connection has been made, make a subscription and send a message.
       console.log("onConnect");
       client.subscribe("weather/loop");
-      document.getElementById("connect").innerHTML = "Live";
+      setStatus(true);
+    }
+
+    function onFailure(responseObject) {
+      console.log("onFailure:" + responseObject.errorMessage);
+      setStatus(false);
     }
 
     // called when the client loses its connection
     function onConnectionLost(responseObject) {
       if (responseObject.errorCode !== 0) {
         console.log("onConnectionLost:" + responseObject.errorMessage);
-        document.getElementById("connect").innerHTML = responseObject.errorMessage;
+        setStatus(false);
       }
     }
 
@@ -211,6 +217,17 @@ require_once '../dbconn.php';
     //ll
     function dp(x) {
       return Number.parseFloat(x).toFixed(1);
+    }
+
+    function setStatus(isConnected) {
+      var el = document.getElementById("connect");
+      if (isConnected) {
+        el.className = "flex items-center px-4 mt-2 text-green-500";
+        el.innerHTML = '<i class="fas fa-circle mr-2"></i>Connected';
+      } else {
+        el.className = "flex items-center px-4 mt-2 text-red-500";
+        el.innerHTML = '<i class="fas fa-circle mr-2"></i>Disconnected';
+      }
     }
   </script>
 <?php include('footer.php'); ?>


### PR DESCRIPTION
## Summary
- Move connection status indicator beneath the site name in the sidebar.
- Replace "Live" text with colored connected/disconnected status using Font Awesome icons.
- Update MQTT script to handle connection loss and failures, toggling the status accordingly.

## Testing
- `php -l frontend/header.php`
- `php -l frontend/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b03b1f0eb4832e8e7aff2c9a0978e4