### PR TITLE
Improve graph loading and sidebar selector responsiveness

### DIFF
--- a/frontend/dynamic-graph.php
+++ b/frontend/dynamic-graph.php
@@ -241,7 +241,7 @@ function minmaxgraph($gt, $what, $graphrangedata, $graphaveragedata, $gscale, $s
    
     echo "  <div class=\"container-fluid\"><br>
       <div class=\"card shadow\">
- <div style=\"height: 75vh;\" id=\"container\"></div></div></div>
+ <div style=\"height: 75vh;\" id=\"container\" class=\"flex items-center justify-center bg-gray-200 animate-pulse\">Loading graph...</div></div></div>
 <script type=\"text/javascript\">
  document.addEventListener('DOMContentLoaded', function () {
 
@@ -254,6 +254,8 @@ function minmaxgraph($gt, $what, $graphrangedata, $graphaveragedata, $gscale, $s
       zoomType: 'xy',
       events: {
          load: function() {
+             var container = this.renderTo;
+             container.classList.remove('animate-pulse','bg-gray-200','flex','items-center','justify-center');
              var series = this.series[0],
                  yData = series.yData,
                  min = Math.min(...yData),
@@ -383,7 +385,7 @@ function standardgraph($gt, $what, $graphdata, $gscale, $scale)
     echo "
     <div class=\"container-fluid\"><br>
       <div class=\"card shadow\"><div class=\"card-body\">
- <div style=\"height: 75vh;\" id=\"container\"></div></div></div></div>
+ <div style=\"height: 75vh;\" id=\"container\" class=\"flex items-center justify-center bg-gray-200 animate-pulse\">Loading graph...</div></div></div></div>
  <script type='text/javascript'>
  Highcharts.chart('container', {
      chart: {
@@ -391,6 +393,8 @@ function standardgraph($gt, $what, $graphdata, $gscale, $scale)
          zoomType: 'xy',
          events: {
             load: function() {
+                var container = this.renderTo;
+                container.classList.remove('animate-pulse','bg-gray-200','flex','items-center','justify-center');
                 var series = this.series[0],
                     yData = series.yData,
                     min = Math.min(...yData),

--- a/frontend/graph-selector.php
+++ b/frontend/graph-selector.php
@@ -3,7 +3,7 @@ $what = $_GET['WHAT'] ?? '';
 $scale = $_GET['SCALE'] ?? '';
 $type = $_GET['TYPE'] ?? '';
 ?>
-<form action="/dynamic-graph.php" method="get" class="max-w-sm mx-auto space-y-3">
+<form action="/dynamic-graph.php" method="get" class="space-y-3 px-4">
   <div>
     <label for="what" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Data</label>
     <select id="what" name="WHAT" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">

--- a/frontend/header.php
+++ b/frontend/header.php
@@ -46,18 +46,18 @@ $minTemp = $row['minTemp'];
   <meta name="Keywords" content="Weather" />
   <meta name="Description" content="Personal Weather Site" />
   <link rel="home" href="/" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
-  <script src="https://kit.fontawesome.com/55c3f37ab0.js" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js" defer></script>
+  <script src="https://kit.fontawesome.com/55c3f37ab0.js" crossorigin="anonymous" defer></script>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
-  <script src="https://code.highcharts.com/stock/highstock.js"></script>
-  <script src="https://code.highcharts.com/highcharts-more.js"></script>
-  <script src="https://code.highcharts.com/modules/boost.js"></script>
-  <script src="https://code.highcharts.com/modules/data.js"></script>
-  <script src="https://code.highcharts.com/modules/exporting.js"></script>
-  <script src="https://code.highcharts.com/modules/solid-gauge.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/canvg/3.0.7/umd.min.js"></script>
+  <script src="https://code.highcharts.com/stock/highstock.js" defer></script>
+  <script src="https://code.highcharts.com/highcharts-more.js" defer></script>
+  <script src="https://code.highcharts.com/modules/boost.js" defer></script>
+  <script src="https://code.highcharts.com/modules/data.js" defer></script>
+  <script src="https://code.highcharts.com/modules/exporting.js" defer></script>
+  <script src="https://code.highcharts.com/modules/solid-gauge.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/canvg/3.0.7/umd.min.js" defer></script>
   <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png">


### PR DESCRIPTION
## Summary
- Load Highcharts and other heavy scripts with `defer` for faster initial rendering
- Style graph selector form to fit the sidebar layout
- Show skeleton placeholder for graphs and remove once chart loads

## Testing
- `php -l frontend/header.php`
- `php -l frontend/graph-selector.php`
- `php -l frontend/dynamic-graph.php`


------
https://chatgpt.com/codex/tasks/task_e_68b03dee6810832ebd8fcf5ca36e9882