### PR TITLE
Simplify html tag in header

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -28,7 +28,7 @@ $maxTemp = $row['maxTemp'];
 $minTemp = $row['minTemp'];
 ?>
 <!DOCTYPE html>
-<html xmlns="https://www.w3.org/1999/xhtml" xml:lang="en-UK" lang="en-UK">
+<html lang="en-UK">
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
   <meta http-equiv="refresh" content="3600">


### PR DESCRIPTION
## Summary
- replace XHTML root element with HTML5-friendly `<html lang="en-UK">` in header template

## Testing
- `php -l frontend/header.php`
- `php -S 127.0.0.1:8000 -t frontend >/tmp/php_server.log 2>&1 &
  sleep 1
  curl -I http://127.0.0.1:8000/index.php
  pkill -f "php -S 127.0.0.1:8000 -t frontend" > /dev/null 2>&1`

------
https://chatgpt.com/codex/tasks/task_e_68b04111cc44832e927380199d8ede87