### PR TITLE
Fix Highcharts loading errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Record any additional project decisions or conventions in this file.
 - Tailwind CSS provides project-wide styling and Font Awesome supplies icons.
 - Headings use bold **Roboto**, body text **Inter**, and buttons or highlights light **Source Sans Pro**.
 - Sections should be wrapped in card components (`bg-white shadow rounded p-4`).
+- Highcharts libraries are loaded from the official CDN; ensure any custom chart scripts run after `DOMContentLoaded` so `Highcharts` is available.
 
 ## Verification
 Before committing, run syntax checks for changed PHP files. Example:

--- a/frontend/dynamic-graph.php
+++ b/frontend/dynamic-graph.php
@@ -387,6 +387,7 @@ function standardgraph($gt, $what, $graphdata, $gscale, $scale)
       <div class=\"card shadow\"><div class=\"card-body\">
  <div style=\"height: 75vh;\" id=\"container\" class=\"flex items-center justify-center bg-gray-200 animate-pulse\">Loading graph...</div></div></div></div>
  <script type='text/javascript'>
+ document.addEventListener('DOMContentLoaded', function () {
  Highcharts.chart('container', {
      chart: {
          type: '$gt',
@@ -510,7 +511,7 @@ function standardgraph($gt, $what, $graphdata, $gscale, $scale)
          }
  }]
 });
-
+});
  </script>
  ";
 }

--- a/frontend/header.php
+++ b/frontend/header.php
@@ -51,8 +51,8 @@ $minTemp = $row['minTemp'];
   <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js" defer></script>
   <script src="https://kit.fontawesome.com/55c3f37ab0.js" crossorigin="anonymous" defer></script>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
-  <script src="js/highstock.js" defer></script>
-  <script src="js/exporting.js" defer></script>
+  <script src="https://code.highcharts.com/stock/highstock.js" defer></script>
+  <script src="https://code.highcharts.com/modules/exporting.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/canvg/3.0.7/umd.min.js" defer></script>
   <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">


### PR DESCRIPTION
## Summary
- Load Highcharts/Highstock and exporting modules from official CDN
- Delay standard chart initialization until `DOMContentLoaded`
- Document CDN usage for Highcharts

## Testing
- `php -l frontend/header.php`
- `php -l frontend/dynamic-graph.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0432db998832e99f6a055fb903893