### PR TITLE
refactor: centralize ini settings

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+$compression = ini_set('zlib.output_compression', '1');
+if ($compression === false) {
+  error_log('Failed to enable zlib.output_compression');
+}
+
+$compressionLevel = ini_set('zlib.output_compression_level', '6');
+if ($compressionLevel === false) {
+  error_log('Failed to set zlib.output_compression_level');
+}
+?>

--- a/frontend/header.php
+++ b/frontend/header.php
@@ -1,6 +1,6 @@
 <?php
-@ini_set('zlib.output_compression', 1);
-@ini_set('zlib.output_compression_level', 6);
+require_once __DIR__ . '/../bootstrap.php';
+
 date_default_timezone_set("Europe/London");
 setlocale(LC_ALL, 'uk_UA.utf8');
 


### PR DESCRIPTION
## Summary
- move output compression configuration into new `bootstrap.php` with error logging
- include the bootstrap file in `frontend/header.php`

## Testing
- `php -l bootstrap.php`
- `php -l frontend/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0433bd1e8832ebf90b908d3a92abd