### PR TITLE
Remove trailing whitespace from astro index

### DIFF
--- a/frontend/astro/index.php
+++ b/frontend/astro/index.php
@@ -245,6 +245,3 @@ echo "\n<div class=\"border-l-4 border-$color bg-white shadow rounded p-2\">\n  
 
 
 echo '</div></div>';
-
-?>
-


### PR DESCRIPTION
## Summary
- remove final PHP closing tag in `frontend/astro/index.php` to avoid trailing whitespace issues

## Testing
- `php -l frontend/astro/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b044c870a4832eb72468a92d09ce39