### PR TITLE
Load Highcharts columnrange module for min/max graphs

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -52,6 +52,7 @@ $minTemp = $row['minTemp'];
   <script src="https://kit.fontawesome.com/55c3f37ab0.js" crossorigin="anonymous" defer></script>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
   <script src="https://code.highcharts.com/stock/highstock.js" defer></script>
+  <script src="https://code.highcharts.com/modules/columnrange.js" defer></script>
   <script src="https://code.highcharts.com/modules/exporting.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/canvg/3.0.7/umd.min.js" defer></script>
   <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png">


### PR DESCRIPTION
## Summary
- Load Highcharts columnrange module in header so columnrange series work

## Testing
- `php -l frontend/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b04639090c832e9aa81aa11a36c046