### PR TITLE
feat: include Highcharts more module in header

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -52,6 +52,7 @@ $minTemp = $row['minTemp'];
   <script src="https://kit.fontawesome.com/55c3f37ab0.js" crossorigin="anonymous" defer></script>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
   <script src="https://code.highcharts.com/stock/highstock.js" defer></script>
+  <script src="https://code.highcharts.com/highcharts-more.js" defer></script>
   <script src="https://code.highcharts.com/modules/columnrange.js" defer></script>
   <script src="https://code.highcharts.com/modules/exporting.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/canvg/3.0.7/umd.min.js" defer></script>


### PR DESCRIPTION
## Summary
- include Highcharts more CDN in header so all pages can use it

## Testing
- `php -l frontend/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b04987cbc0832e947401b53a7b01fa