### PR TITLE
Fix sidebar transition behavior

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -74,7 +74,7 @@ $minTemp = $row['minTemp'];
     </svg>
   </button>
     <div class="flex min-h-screen">
-      <aside id="sidebar" class="bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 w-64 space-y-2 py-4 px-2 absolute inset-y-0 left-0 z-40 transform -translate-x-full md:relative md:translate-x-0 transition duration-200 ease-in-out">
+      <aside id="sidebar" class="bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 w-64 space-y-2 py-4 px-2 absolute inset-y-0 left-0 z-40 transform -translate-x-full md:relative md:translate-x-0 transition-transform duration-200 ease-in-out">
       <a id="navname" class="flex items-center space-x-2 px-4" href="/">
         <img src="/images/icon.png" class="w-8 h-8" alt="Site icon">
         <span>Wheathampstead Weather</span>


### PR DESCRIPTION
## Summary
- Restrict sidebar to transform-only transitions so vertical movement doesn't animate

## Testing
- `php -l frontend/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b08e93fe34832e9b8ca8c3d9992a9b