### PR TITLE
Add seasonal patterns section with monthly averages

### DIFF
--- a/frontend/backend/seasonal-data.php
+++ b/frontend/backend/seasonal-data.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__ . '/../../dbconn.php';
+
+header('Content-Type: application/json');
+
+$sql = "
+  SELECT
+    MONTH(FROM_UNIXTIME(dateTime)) AS month,
+    DATE_FORMAT(FROM_UNIXTIME(dateTime), '%b') AS month_name,
+    AVG(outTemp) AS avgTemp,
+    SUM(rain) AS totalRain
+  FROM weewx.archive
+  GROUP BY month
+  ORDER BY month;
+";
+
+$result = db_query($sql);
+$data = [];
+
+while ($row = mysqli_fetch_assoc($result)) {
+  $data[] = [
+    'month' => (int) $row['month'],
+    'month_name' => $row['month_name'],
+    'avgTemp' => round($row['avgTemp'], 1),
+    'totalRain' => round($row['totalRain'], 1)
+  ];
+}
+
+echo json_encode($data);
+?>

--- a/frontend/header.php
+++ b/frontend/header.php
@@ -90,6 +90,7 @@ $minTemp = $row['minTemp'];
           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/reportwindyeartotals.php"><i class="fas fa-wind text-blue-500 mr-2"></i>Wind By Year</a>
           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/records.php"><i class="fas fa-book text-blue-500 mr-2"></i>Records</a>
           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/windrose.php"><i class="fas fa-compass text-blue-500 mr-2"></i>Wind Rose</a>
+          <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/seasonal.php"><i class="fas fa-calendar-alt text-blue-500 mr-2"></i>Seasonal</a>
           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/picture.php"><i class="fas fa-camera text-blue-500 mr-2"></i>Webcam</a>
           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/astro"><i class="fas fa-star text-blue-500 mr-2"></i>Astro</a>
           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="http://ob.smeird.com"><i class="fas fa-cloud-sun text-blue-500 mr-2"></i>Sky Weather</a>

--- a/frontend/seasonal.php
+++ b/frontend/seasonal.php
@@ -1,0 +1,40 @@
+<?php include('header.php'); ?>
+<div class="bg-white shadow rounded p-4">
+  <h2 class="text-xl font-bold mb-4">Seasonal Patterns</h2>
+  <div id="seasonal-chart" class="mb-4"></div>
+  <table class="min-w-full divide-y divide-gray-200">
+    <thead class="bg-gray-50">
+      <tr>
+        <th class="px-4 py-2 text-left">Month</th>
+        <th class="px-4 py-2 text-left">Avg Temp (°C)</th>
+        <th class="px-4 py-2 text-left">Total Rain (mm)</th>
+      </tr>
+    </thead>
+    <tbody id="seasonal-table" class="bg-white divide-y divide-gray-200"></tbody>
+  </table>
+</div>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    fetch('backend/seasonal-data.php')
+      .then(function(resp) { return resp.json(); })
+      .then(function(data) {
+        var tbody = document.getElementById('seasonal-table');
+        data.forEach(function(row) {
+          var tr = document.createElement('tr');
+          tr.innerHTML = '<td class="px-4 py-2">' + row.month_name + '</td>' +
+            '<td class="px-4 py-2">' + row.avgTemp.toFixed(1) + '</td>' +
+            '<td class="px-4 py-2">' + row.totalRain.toFixed(1) + '</td>';
+          tbody.appendChild(tr);
+        });
+        Highcharts.chart('seasonal-chart', {
+          chart: { type: 'spline' },
+          title: { text: 'Average Monthly Temperature' },
+          xAxis: { categories: data.map(function(r) { return r.month_name; }) },
+          yAxis: { title: { text: 'Temperature (°C)' } },
+          series: [{ name: 'Avg Temp', data: data.map(function(r) { return r.avgTemp; }) }],
+          credits: { enabled: false }
+        });
+      });
+  });
+</script>
+<?php include('footer.php'); ?>


### PR DESCRIPTION
## Summary
- Add seasonal patterns page that charts average monthly temperature and rainfall totals
- Provide backend endpoint to supply aggregated monthly data
- Link seasonal patterns page in navigation

## Testing
- `php -l frontend/backend/seasonal-data.php`
- `php -l frontend/seasonal.php`
- `php -l frontend/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b08de5c334832ea927b183fb74eea1