### PR TITLE
Add multi-year seasonal view and restore seasonal link

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -90,6 +90,7 @@ $minTemp = $row['minTemp'];
           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/reportwindyeartotals.php"><i class="fas fa-wind text-blue-500 mr-2"></i>Wind By Year</a>
           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/records.php"><i class="fas fa-book text-blue-500 mr-2"></i>Records</a>
           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/windrose.php"><i class="fas fa-compass text-blue-500 mr-2"></i>Wind Rose</a>
+          <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/seasonal.php"><i class="fas fa-calendar text-blue-500 mr-2"></i>Seasonal</a>
 
           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/last-time.php"><i class="fas fa-history text-blue-500 mr-2"></i>Last Time</a>
 

--- a/frontend/seasonal.php
+++ b/frontend/seasonal.php
@@ -1,10 +1,15 @@
 <?php include('header.php'); ?>
 <div class="bg-white shadow rounded p-4">
   <h2 class="text-xl font-bold mb-4">Seasonal Patterns</h2>
+  <div class="mb-4">
+    <label for="year-select" class="mr-2">Select years:</label>
+    <select id="year-select" multiple class="border rounded p-2"></select>
+  </div>
   <div id="seasonal-chart" class="mb-4"></div>
   <table class="min-w-full divide-y divide-gray-200">
     <thead class="bg-gray-50">
       <tr>
+        <th class="px-4 py-2 text-left">Year</th>
         <th class="px-4 py-2 text-left">Month</th>
         <th class="px-4 py-2 text-left">Avg Temp (°C)</th>
         <th class="px-4 py-2 text-left">Total Rain (mm)</th>
@@ -15,26 +20,56 @@
 </div>
 <script>
   document.addEventListener('DOMContentLoaded', function() {
+    var allData = {};
+    var yearSelect = document.getElementById('year-select');
     fetch('backend/seasonal-data.php')
       .then(function(resp) { return resp.json(); })
       .then(function(data) {
-        var tbody = document.getElementById('seasonal-table');
-        data.forEach(function(row) {
+        allData = data;
+        Object.keys(data).sort().forEach(function(year) {
+          var opt = document.createElement('option');
+          opt.value = year;
+          opt.text = year;
+          yearSelect.appendChild(opt);
+        });
+        if (yearSelect.options.length) {
+          yearSelect.options[yearSelect.options.length - 1].selected = true;
+        }
+        render();
+      });
+
+    yearSelect.addEventListener('change', render);
+
+    function render() {
+      var selected = Array.from(yearSelect.selectedOptions).map(function(o) { return o.value; });
+      var tbody = document.getElementById('seasonal-table');
+      tbody.innerHTML = '';
+      var categories = [];
+      var series = [];
+      selected.forEach(function(year) {
+        var rows = allData[year] || [];
+        rows.forEach(function(row) {
           var tr = document.createElement('tr');
-          tr.innerHTML = '<td class="px-4 py-2">' + row.month_name + '</td>' +
+          tr.innerHTML = '<td class="px-4 py-2">' + year + '</td>' +
+            '<td class="px-4 py-2">' + row.month_name + '</td>' +
             '<td class="px-4 py-2">' + row.avgTemp.toFixed(1) + '</td>' +
             '<td class="px-4 py-2">' + row.totalRain.toFixed(1) + '</td>';
           tbody.appendChild(tr);
         });
-        Highcharts.chart('seasonal-chart', {
-          chart: { type: 'spline' },
-          title: { text: 'Average Monthly Temperature' },
-          xAxis: { categories: data.map(function(r) { return r.month_name; }) },
-          yAxis: { title: { text: 'Temperature (°C)' } },
-          series: [{ name: 'Avg Temp', data: data.map(function(r) { return r.avgTemp; }) }],
-          credits: { enabled: false }
-        });
+        if (!categories.length) {
+          categories = rows.map(function(r) { return r.month_name; });
+        }
+        series.push({ name: year, data: rows.map(function(r) { return r.avgTemp; }) });
       });
+      Highcharts.chart('seasonal-chart', {
+        chart: { type: 'spline' },
+        title: { text: 'Average Monthly Temperature' },
+        xAxis: { categories: categories },
+        yAxis: { title: { text: 'Temperature (°C)' } },
+        series: series,
+        credits: { enabled: false }
+      });
+    }
   });
 </script>
 <?php include('footer.php'); ?>


### PR DESCRIPTION
## Summary
- Restore missing navigation link to seasonal page
- Allow selecting multiple years on seasonal page and display data per year
- Update backend seasonal endpoint to group results by year and support filtering

## Testing
- `php -l frontend/header.php`
- `php -l frontend/seasonal.php`
- `php -l frontend/backend/seasonal-data.php`


------
https://chatgpt.com/codex/tasks/task_e_68b094c6bbc0832e9293e84b87024349