### PR TITLE
Stop pulsing animation on last time graph

### DIFF
--- a/frontend/last-time.php
+++ b/frontend/last-time.php
@@ -83,7 +83,13 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   Highcharts.chart('lastTimeChart', {
     chart: {
-      type: 'area'
+      type: 'area',
+      events: {
+        load: function () {
+          var container = this.renderTo;
+          container.classList.remove('animate-pulse', 'bg-gray-200', 'flex', 'items-center', 'justify-center');
+        }
+      }
     },
     title: { text: '<?php echo $what; ?> for <?php echo $month ? date('F', mktime(0,0,0,$month,1)) : ''; ?>' },
     xAxis: { title: { text: 'Day of Month' } },


### PR DESCRIPTION
## Summary
- remove Tailwind `animate-pulse` class after chart loads in `last-time.php`

## Testing
- `php -l frontend/last-time.php`


------
https://chatgpt.com/codex/tasks/task_e_68b096d620a0832ea2667e5dc153758e