### PR TITLE
feat: add statistic selector for seasonal temps

### DIFF
--- a/frontend/backend/seasonal-data.php
+++ b/frontend/backend/seasonal-data.php
@@ -10,12 +10,21 @@ if (!empty($years)) {
   $where = 'WHERE YEAR(FROM_UNIXTIME(dateTime)) IN (' . implode(',', $years) . ')';
 }
 
+$stat = isset($_GET['stat']) ? strtolower($_GET['stat']) : 'avg';
+$funcMap = [
+  'min' => 'MIN',
+  'max' => 'MAX',
+  'avg' => 'AVG',
+  'mean' => 'AVG'
+];
+$func = isset($funcMap[$stat]) ? $funcMap[$stat] : 'AVG';
+
 $sql = "
   SELECT
     YEAR(FROM_UNIXTIME(dateTime)) AS year,
     MONTH(FROM_UNIXTIME(dateTime)) AS month,
     DATE_FORMAT(FROM_UNIXTIME(dateTime), '%b') AS month_name,
-    AVG(outTemp) AS avgTemp,
+    $func(outTemp) AS temp,
     SUM(rain) AS totalRain
   FROM weewx.archive
   $where
@@ -34,7 +43,7 @@ while ($row = mysqli_fetch_assoc($result)) {
   $data[$year][] = [
     'month' => (int) $row['month'],
     'month_name' => $row['month_name'],
-    'avgTemp' => round($row['avgTemp'], 1),
+    'temp' => round($row['temp'], 1),
     'totalRain' => round($row['totalRain'], 1)
   ];
 }

--- a/frontend/seasonal.php
+++ b/frontend/seasonal.php
@@ -5,13 +5,21 @@
     <label for="year-select" class="mr-2">Select years:</label>
     <select id="year-select" multiple class="border rounded p-2"></select>
   </div>
+  <div class="mb-4">
+    <label for="stat-select" class="mr-2">Statistic:</label>
+    <select id="stat-select" class="border rounded p-2">
+      <option value="avg">Average</option>
+      <option value="min">Minimum</option>
+      <option value="max">Maximum</option>
+    </select>
+  </div>
   <div id="seasonal-chart" class="mb-4"></div>
   <table class="min-w-full divide-y divide-gray-200">
     <thead class="bg-gray-50">
       <tr>
         <th class="px-4 py-2 text-left">Year</th>
         <th class="px-4 py-2 text-left">Month</th>
-        <th class="px-4 py-2 text-left">Avg Temp (°C)</th>
+        <th id="temp-header" class="px-4 py-2 text-left">Avg Temp (°C)</th>
         <th class="px-4 py-2 text-left">Total Rain (mm)</th>
       </tr>
     </thead>
@@ -22,23 +30,35 @@
   document.addEventListener('DOMContentLoaded', function() {
     var allData = {};
     var yearSelect = document.getElementById('year-select');
-    fetch('backend/seasonal-data.php')
-      .then(function(resp) { return resp.json(); })
-      .then(function(data) {
-        allData = data;
-        Object.keys(data).sort().forEach(function(year) {
-          var opt = document.createElement('option');
-          opt.value = year;
-          opt.text = year;
-          yearSelect.appendChild(opt);
-        });
-        if (yearSelect.options.length) {
-          yearSelect.options[yearSelect.options.length - 1].selected = true;
-        }
-        render();
-      });
+    var statSelect = document.getElementById('stat-select');
 
-    yearSelect.addEventListener('change', render);
+    function loadData() {
+      var selectedYears = Array.from(yearSelect.selectedOptions).map(function(o) { return o.value; });
+      fetch('backend/seasonal-data.php?stat=' + statSelect.value)
+        .then(function(resp) { return resp.json(); })
+        .then(function(data) {
+          allData = data;
+          yearSelect.innerHTML = '';
+          Object.keys(data).sort().forEach(function(year) {
+            var opt = document.createElement('option');
+            opt.value = year;
+            opt.text = year;
+            if (selectedYears.indexOf(year) !== -1) {
+              opt.selected = true;
+            }
+            yearSelect.appendChild(opt);
+          });
+          if (yearSelect.selectedOptions.length === 0 && yearSelect.options.length) {
+            yearSelect.options[yearSelect.options.length - 1].selected = true;
+          }
+          render();
+        });
+    }
+
+    function getStatLabel() {
+      var map = { min: 'Min', max: 'Max', avg: 'Avg' };
+      return map[statSelect.value] || 'Avg';
+    }
 
     function render() {
       var selected = Array.from(yearSelect.selectedOptions).map(function(o) { return o.value; });
@@ -52,24 +72,30 @@
           var tr = document.createElement('tr');
           tr.innerHTML = '<td class="px-4 py-2">' + year + '</td>' +
             '<td class="px-4 py-2">' + row.month_name + '</td>' +
-            '<td class="px-4 py-2">' + row.avgTemp.toFixed(1) + '</td>' +
+            '<td class="px-4 py-2">' + row.temp.toFixed(1) + '</td>' +
             '<td class="px-4 py-2">' + row.totalRain.toFixed(1) + '</td>';
           tbody.appendChild(tr);
         });
         if (!categories.length) {
           categories = rows.map(function(r) { return r.month_name; });
         }
-        series.push({ name: year, data: rows.map(function(r) { return r.avgTemp; }) });
+        series.push({ name: year, data: rows.map(function(r) { return r.temp; }) });
       });
+      document.getElementById('temp-header').textContent = getStatLabel() + ' Temp (°C)';
       Highcharts.chart('seasonal-chart', {
         chart: { type: 'spline' },
-        title: { text: 'Average Monthly Temperature' },
+        title: { text: getStatLabel() + ' Monthly Temperature' },
         xAxis: { categories: categories },
         yAxis: { title: { text: 'Temperature (°C)' } },
         series: series,
         credits: { enabled: false }
       });
     }
+
+    statSelect.addEventListener('change', loadData);
+    yearSelect.addEventListener('change', render);
+
+    loadData();
   });
 </script>
 <?php include('footer.php'); ?>


### PR DESCRIPTION
## Summary
- allow seasonal page to choose temperature statistic (avg/min/max)
- backend seasonal endpoint supports dynamic stat queries

## Testing
- `php -l frontend/backend/seasonal-data.php`
- `php -l frontend/seasonal.php`


------
https://chatgpt.com/codex/tasks/task_e_68b09664b43c832ebbeeed3d6772d697