### PR TITLE
Add export endpoint for backend data

### DIFF
--- a/frontend/backend/export-data.php
+++ b/frontend/backend/export-data.php
@@ -1,0 +1,33 @@
+<?php
+require_once '../../dbconn.php';
+
+$start = isset($_GET['start']) ? (int)$_GET['start'] : time() - 86400;
+$end = isset($_GET['end']) ? (int)$_GET['end'] : time();
+
+if ($start > $end) {
+  http_response_code(400);
+  exit('Invalid time range');
+}
+
+$sql = sprintf(
+  "SELECT dateTime, outTemp, outHumidity, windSpeed, windGust, windDir, barometer, pressure, rain, rainRate, dewpoint, heatindex, windchill, radiation, UV FROM archive WHERE dateTime BETWEEN %d AND %d ORDER BY dateTime",
+  $start,
+  $end
+);
+$result = db_query($sql);
+$data = [];
+while ($row = mysqli_fetch_assoc($result)) {
+  $data[] = $row;
+}
+mysqli_free_result($result);
+mysqli_close($link);
+
+$json = json_encode($data);
+$gzdata = gzencode($json);
+
+header('Content-Type: application/json');
+header('Content-Encoding: gzip');
+header('Content-Disposition: attachment; filename="weather-data.json.gz"');
+header('Content-Length: ' . strlen($gzdata));
+
+echo $gzdata;

--- a/frontend/export.php
+++ b/frontend/export.php
@@ -1,0 +1,13 @@
+<?php
+include('header.php');
+?>
+<div>
+  <div class="flex flex-col sm:flex-row items-center justify-between mb-2">
+    <h1 class="text-2xl text-gray-800">Export Data</h1>
+  </div>
+  <div class="bg-white shadow rounded p-4">
+    <p class="mb-4">Download weather observations as a gzipped JSON file.</p>
+    <a href="backend/export-data.php" class="inline-block text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"><i class="fas fa-download mr-2"></i>Download</a>
+  </div>
+</div>
+<?php include('footer.php');

--- a/frontend/header.php
+++ b/frontend/header.php
@@ -94,8 +94,9 @@ $minTemp = $row['minTemp'];
 
           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/last-time.php"><i class="fas fa-history text-blue-500 mr-2"></i>Last Time</a>
 
-          <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/picture.php"><i class="fas fa-camera text-blue-500 mr-2"></i>Webcam</a>
-          <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/astro"><i class="fas fa-star text-blue-500 mr-2"></i>Astro</a>
+           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/picture.php"><i class="fas fa-camera text-blue-500 mr-2"></i>Webcam</a>
+           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/export.php"><i class="fas fa-file-export text-blue-500 mr-2"></i>Export Data</a>
+           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="/astro"><i class="fas fa-star text-blue-500 mr-2"></i>Astro</a>
           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="http://ob.smeird.com"><i class="fas fa-cloud-sun text-blue-500 mr-2"></i>Sky Weather</a>
           <a class="flex items-center w-full py-2.5 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700" href="http://power.smeird.com"><i class="fas fa-bolt text-blue-500 mr-2"></i>Power Use</a>
 


### PR DESCRIPTION
## Summary
- Add navigation link and export page to download weather data
- Provide backend endpoint that returns archive data as gzipped JSON

## Testing
- `php -l frontend/header.php`
- `php -l frontend/export.php`
- `php -l frontend/backend/export-data.php`


------
https://chatgpt.com/codex/tasks/task_e_68b09b4f7d70832e8213b842a467509e