### PR TITLE
Remove markers and lighten fill on last time chart

### DIFF
--- a/frontend/last-time.php
+++ b/frontend/last-time.php
@@ -95,6 +95,10 @@ document.addEventListener('DOMContentLoaded', function () {
     xAxis: { title: { text: 'Day of Month' } },
     yAxis: { title: { text: '<?php echo $what; ?>' } },
     tooltip: { shared: true },
+    plotOptions: {
+      series: { marker: { enabled: false } },
+      area: { fillOpacity: 0.1 }
+    },
     series: series
   });
 });


### PR DESCRIPTION
## Summary
- Remove data point markers from last time chart series
- Reduce area fill opacity for a lighter line appearance

## Testing
- `php -l frontend/last-time.php`


------
https://chatgpt.com/codex/tasks/task_e_68b09c814c4c832e9087de1e0ff1f598