### PR TITLE
Style seasonal filters with Tailwind

### DIFF
--- a/frontend/seasonal.php
+++ b/frontend/seasonal.php
@@ -1,17 +1,19 @@
 <?php include('header.php'); ?>
 <div class="bg-white shadow rounded p-4">
   <h2 class="text-xl font-bold mb-4">Seasonal Patterns</h2>
-  <div class="mb-4">
-    <label for="year-select" class="mr-2">Select years:</label>
-    <select id="year-select" multiple class="border rounded p-2"></select>
-  </div>
-  <div class="mb-4">
-    <label for="stat-select" class="mr-2">Statistic:</label>
-    <select id="stat-select" class="border rounded p-2">
-      <option value="avg">Average</option>
-      <option value="min">Minimum</option>
-      <option value="max">Maximum</option>
-    </select>
+  <div class="mb-4 flex flex-wrap gap-4">
+    <div class="flex items-center gap-2">
+      <label for="year-select">Select years:</label>
+      <select id="year-select" multiple class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></select>
+    </div>
+    <div class="flex items-center gap-2">
+      <label for="stat-select">Statistic:</label>
+      <select id="stat-select" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+        <option value="avg">Average</option>
+        <option value="min">Minimum</option>
+        <option value="max">Maximum</option>
+      </select>
+    </div>
   </div>
   <div id="seasonal-chart" class="mb-4"></div>
   <table class="min-w-full divide-y divide-gray-200">


### PR DESCRIPTION
## Summary
- Restyle seasonal page filters with Tailwind classes to match sidebar select styling.
- Arrange year and statistic selectors inline for a cleaner layout.

## Testing
- `php -l frontend/seasonal.php`


------
https://chatgpt.com/codex/tasks/task_e_68b09d768ecc832ea81893631908d8c6