### PR TITLE
Add median and std statistics to seasonal reports

### DIFF
--- a/frontend/backend/seasonal-data.php
+++ b/frontend/backend/seasonal-data.php
@@ -15,9 +15,61 @@ $funcMap = [
   'min' => 'MIN',
   'max' => 'MAX',
   'avg' => 'AVG',
-  'mean' => 'AVG'
+  'mean' => 'AVG',
+  'std' => 'STDDEV',
+  'median' => null
 ];
 $func = isset($funcMap[$stat]) ? $funcMap[$stat] : 'AVG';
+if ($stat === 'median') {
+  $sql = "
+    SELECT
+      YEAR(FROM_UNIXTIME(dateTime)) AS year,
+      MONTH(FROM_UNIXTIME(dateTime)) AS month,
+      DATE_FORMAT(FROM_UNIXTIME(dateTime), '%b') AS month_name,
+      outTemp,
+      rain
+    FROM weewx.archive
+    $where
+    ORDER BY year, month;
+  ";
+  $result = db_query($sql);
+  $raw = [];
+  while ($row = mysqli_fetch_assoc($result)) {
+    $year = $row['year'];
+    $month = (int) $row['month'];
+    if (!isset($raw[$year])) {
+      $raw[$year] = [];
+    }
+    if (!isset($raw[$year][$month])) {
+      $raw[$year][$month] = [
+        'month_name' => $row['month_name'],
+        'temps' => [],
+        'totalRain' => 0
+      ];
+    }
+    $raw[$year][$month]['temps'][] = (float) $row['outTemp'];
+    $raw[$year][$month]['totalRain'] += (float) $row['rain'];
+  }
+  $data = [];
+  foreach ($raw as $year => $months) {
+    $data[$year] = [];
+    foreach ($months as $month => $info) {
+      $temps = $info['temps'];
+      sort($temps);
+      $count = count($temps);
+      $mid = (int) ($count / 2);
+      $median = $count % 2 ? $temps[$mid] : ($temps[$mid - 1] + $temps[$mid]) / 2;
+      $data[$year][] = [
+        'month' => $month,
+        'month_name' => $info['month_name'],
+        'temp' => round($median, 1),
+        'totalRain' => round($info['totalRain'], 1)
+      ];
+    }
+  }
+  echo json_encode($data);
+  exit;
+}
 
 $sql = "
   SELECT

--- a/frontend/seasonal.php
+++ b/frontend/seasonal.php
@@ -11,6 +11,8 @@
       <option value="avg">Average</option>
       <option value="min">Minimum</option>
       <option value="max">Maximum</option>
+      <option value="median">Median</option>
+      <option value="std">Std Dev</option>
     </select>
   </div>
   <div id="seasonal-chart" class="mb-4"></div>
@@ -56,7 +58,7 @@
     }
 
     function getStatLabel() {
-      var map = { min: 'Min', max: 'Max', avg: 'Avg' };
+      var map = { min: 'Min', max: 'Max', avg: 'Avg', median: 'Median', std: 'Std Dev' };
       return map[statSelect.value] || 'Avg';
     }
 
@@ -81,10 +83,13 @@
         }
         series.push({ name: year, data: rows.map(function(r) { return r.temp; }) });
       });
-      document.getElementById('temp-header').textContent = getStatLabel() + ' Temp (°C)';
+      var stat = statSelect.value;
+      document.getElementById('temp-header').textContent = stat === 'std'
+        ? 'Temp ' + getStatLabel() + ' (°C)'
+        : getStatLabel() + ' Temp (°C)';
       Highcharts.chart('seasonal-chart', {
         chart: { type: 'spline' },
-        title: { text: getStatLabel() + ' Monthly Temperature' },
+        title: { text: stat === 'std' ? 'Monthly Temp ' + getStatLabel() : getStatLabel() + ' Monthly Temperature' },
         xAxis: { categories: categories },
         yAxis: { title: { text: 'Temperature (°C)' } },
         series: series,


### PR DESCRIPTION
## Summary
- add Median and Std Dev options to seasonal statistics selector and labels
- compute median and std dev seasonal values and expose via backend

## Testing
- `php -l frontend/seasonal.php`
- `php -l frontend/backend/seasonal-data.php`


------
https://chatgpt.com/codex/tasks/task_e_68b09db467b4832e8076b564cdf8da82