### PR TITLE
Add export date range slider

### DIFF
--- a/frontend/export.php
+++ b/frontend/export.php
@@ -1,5 +1,7 @@
 <?php
 include('header.php');
+$now = time();
+$yearAgo = $now - 31536000;
 ?>
 <div>
   <div class="flex flex-col sm:flex-row items-center justify-between mb-2">
@@ -7,7 +9,51 @@ include('header.php');
   </div>
   <div class="bg-white shadow rounded p-4">
     <p class="mb-4">Download weather observations as a gzipped JSON file.</p>
-    <a href="backend/export-data.php" class="inline-block text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"><i class="fas fa-download mr-2"></i>Download</a>
+    <div class="mb-4 range-slider">
+      <div class="relative h-2">
+        <input id="startRange" type="range" min="<?php echo $yearAgo; ?>" max="<?php echo $now; ?>" value="<?php echo $yearAgo; ?>" step="86400" class="absolute top-0 left-0 w-full h-2 appearance-none bg-transparent">
+        <input id="endRange" type="range" min="<?php echo $yearAgo; ?>" max="<?php echo $now; ?>" value="<?php echo $now; ?>" step="86400" class="absolute top-0 left-0 w-full h-2 appearance-none bg-transparent">
+      </div>
+      <div class="flex justify-between text-sm mt-6">
+        <span id="startLabel"></span>
+        <span id="endLabel"></span>
+      </div>
+    </div>
+    <a id="downloadLink" href="backend/export-data.php" class="inline-block text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"><i class="fas fa-download mr-2"></i>Download</a>
   </div>
 </div>
-<?php include('footer.php');
+<style>
+  .range-slider input[type=range] {
+    pointer-events: none;
+  }
+  .range-slider input[type=range]::-webkit-slider-thumb {
+    pointer-events: all;
+  }
+  .range-slider input[type=range]::-moz-range-thumb {
+    pointer-events: all;
+  }
+</style>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const start = document.getElementById('startRange');
+    const end = document.getElementById('endRange');
+    const startLabel = document.getElementById('startLabel');
+    const endLabel = document.getElementById('endLabel');
+    const download = document.getElementById('downloadLink');
+
+    function update() {
+      let s = Math.min(parseInt(start.value), parseInt(end.value));
+      let e = Math.max(parseInt(start.value), parseInt(end.value));
+      start.value = s;
+      end.value = e;
+      startLabel.textContent = new Date(s * 1000).toISOString().split('T')[0];
+      endLabel.textContent = new Date(e * 1000).toISOString().split('T')[0];
+      download.href = `backend/export-data.php?start=${s}&end=${e}`;
+    }
+
+    start.addEventListener('input', update);
+    end.addEventListener('input', update);
+    update();
+  });
+</script>
+<?php include('footer.php'); ?>


### PR DESCRIPTION
## Summary
- add draggable start/end range selector to export page
- dynamically update export link and range labels

## Testing
- `php -l frontend/export.php`


------
https://chatgpt.com/codex/tasks/task_e_68b09eba6bd8832e9ccb3fe20f316190