### PR TITLE
Fix duplicated hour scale option

### DIFF
--- a/frontend/dynamic-graph.php
+++ b/frontend/dynamic-graph.php
@@ -2,7 +2,7 @@
 include('header.php');
 require_once '../dbconn.php';
 $allowedWhat = ['rain','rainRate','inTemp','outTemp','barometer','outHumidity','inHumidity','windSpeed','windGust','windDir','windGustDir','dewpoint','windchill'];
-$allowedScale = ['hour','day','48','week','month','qtr','6m','year','all'];
+$allowedScale = ['hour','12h','day','48','week','month','qtr','6m','year','all'];
 $allowedType = ['MINMAX','STANDARD'];
 
 $conditions = [
@@ -131,7 +131,7 @@ if ($date) {
       $groupby = "GROUP BY hour(FROM_UNIXTIME(dateTime)),day(FROM_UNIXTIME(dateTime))";
       $xscale = "600 * 1000";
       break;
-    case "hour":
+    case "12h":
       $scalesql = "WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 12 HOUR) AND UNIX_TIMESTAMP(NOW()) ";
       $groupby = "GROUP BY hour(FROM_UNIXTIME(dateTime)),day(FROM_UNIXTIME(dateTime))";
       $xscale = "600 * 1000";


### PR DESCRIPTION
## Summary
- rename duplicated `hour` case to `12h` in `dynamic-graph.php`
- include `12h` in allowed scale options for dynamic graphs

## Testing
- `php -l frontend/dynamic-graph.php`
- `php -r '$scales=["hour","12h","day","48","week","month","qtr","6m","year","all"]; foreach($scales as $scale){ switch($scale){ case "hour": $scalesql="WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 2 HOUR) AND UNIX_TIMESTAMP(NOW()) "; break; case "12h": $scalesql="WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 12 HOUR) AND UNIX_TIMESTAMP(NOW()) "; break; case "day": $scalesql="WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 1 DAY) AND UNIX_TIMESTAMP(NOW()) "; break; case "48": $scalesql="WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 2 DAY) AND UNIX_TIMESTAMP(NOW()) "; break; case "week": $scalesql="WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 1 WEEK) AND UNIX_TIMESTAMP(NOW()) "; break; case "month": $scalesql="WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 1 MONTH) AND UNIX_TIMESTAMP(NOW()) "; break; case "qtr": $scalesql="WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 3 MONTH) AND UNIX_TIMESTAMP(NOW()) "; break; case "6m": $scalesql="WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 6 MONTH) AND UNIX_TIMESTAMP(NOW()) "; break; case "year": $scalesql="WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 1 YEAR) AND UNIX_TIMESTAMP(NOW()) "; break; case "all": $scalesql="WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 5 YEAR) AND UNIX_TIMESTAMP(NOW()) "; break; default: $scalesql="WHERE dateTime BETWEEN UNIX_TIMESTAMP(NOW() - INTERVAL 1 DAY) AND UNIX_TIMESTAMP(NOW()) ";} echo "$scale -> $scalesql\n"; }'`


------
https://chatgpt.com/codex/tasks/task_e_68b1885b0eac832e9934c694cc6ccdba