### PR TITLE
refactor: remove extract from data loops

### DIFF
--- a/frontend/dynamic-graph.php
+++ b/frontend/dynamic-graph.php
@@ -196,10 +196,9 @@ if ($date) {
         $result = mysqli_stmt_get_result($stmt);
         $rowr = array();
         $rowa = array();
-        while ($row  = mysqli_fetch_assoc($result)) {
-            extract($row);
-            $rowa[] = "[$datetime,$dataavg]";
-            $rowr[] = "[$datetime,$datamin,$datamax]";
+        while ($row = mysqli_fetch_assoc($result)) {
+            $rowa[] = "[{$row['datetime']},{$row['dataavg']}]";
+            $rowr[] = "[{$row['datetime']},{$row['datamin']},{$row['datamax']}]";
         }
         $graphaveragedata = "[\n" . join(",\n", $rowa) . "\n]";
         $graphrangedata = "[\n" . join(",\n", $rowr) . "\n]";
@@ -222,9 +221,8 @@ if ($date) {
         mysqli_stmt_execute($stmt);
         $result = mysqli_stmt_get_result($stmt);
         $rows = array();
-        while ($row  = mysqli_fetch_assoc($result)) {
-            extract($row);
-            $rows[] = "[$datetime,$data]";
+        while ($row = mysqli_fetch_assoc($result)) {
+            $rows[] = "[{$row['datetime']},{$row['data']}]";
         }
         $graphdata = "[\n" . join(",\n", $rows) . "\n]";
 


### PR DESCRIPTION
## Summary
- avoid extract() in dynamic graph loops for clarity

## Testing
- `php -l frontend/dynamic-graph.php`


------
https://chatgpt.com/codex/tasks/task_e_68b18a8d06d0832e81f2c71115a855d6