### PR TITLE
fix: sum archive rain intervals for daily total

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -10,7 +10,7 @@ $sql = "
         round(`archive`.`outTemp`,1) AS `outTemp`,
         (SELECT round(`outTemp`,1) FROM `weewx`.`archive` WHERE dateTime BETWEEN UNIX_TIMESTAMP(CURDATE()) AND UNIX_TIMESTAMP(CURDATE() + INTERVAL 1 DAY) - 1 ORDER BY `outTemp` DESC LIMIT 1) AS `maxTemp`,
         (SELECT round(`outTemp`,1) FROM `weewx`.`archive` WHERE dateTime BETWEEN UNIX_TIMESTAMP(CURDATE()) AND UNIX_TIMESTAMP(CURDATE() + INTERVAL 1 DAY) - 1 ORDER BY `outTemp` ASC LIMIT 1) AS `minTemp`,
-        (SELECT round(max(`rain`) - min(`rain`),1) FROM `weewx`.`archive` WHERE dateTime BETWEEN UNIX_TIMESTAMP(CURDATE()) AND UNIX_TIMESTAMP(CURDATE() + INTERVAL 1 DAY) - 1) AS `rainTotal`
+        (SELECT round(sum(`rain`),1) FROM `weewx`.`archive` WHERE dateTime BETWEEN UNIX_TIMESTAMP(CURDATE()) AND UNIX_TIMESTAMP(CURDATE() + INTERVAL 1 DAY) - 1) AS `rainTotal`
     FROM
         `weewx`.`archive`
     ORDER BY


### PR DESCRIPTION
## Summary
- sum rain intervals to compute daily rainfall for header query

## Testing
- `php -l frontend/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1d4f93b7c832eb2dad97bb0d1f227