### PR TITLE
Add average range graph option

### DIFF
--- a/frontend/graph-selector.php
+++ b/frontend/graph-selector.php
@@ -26,6 +26,7 @@ $type = $_GET['TYPE'] ?? '';
     <select id="typey" name="TYPE" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
       <option value="STANDARD">Standard</option>
       <option value="MINMAX">Min &amp; Max</option>
+      <option value="AVG">Average Range</option>
     </select>
   </div>
   <div>


### PR DESCRIPTION
## Summary
- Extend graph selector with new **Average Range** option
- Support `AVG` graph type to render min/max area with average line

## Testing
- `php -l frontend/graph-selector.php`
- `php -l frontend/dynamic-graph.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5d3bdeda4832e805affc0d3bdf730