### PR TITLE
feat: standardize graph tooltips

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -63,6 +63,12 @@ $rainTotal = $row['rainTotal'];
       if (window.Highcharts && Highcharts.theme) {
         Highcharts.setOptions(Highcharts.theme);
       }
+      if (window.Highcharts) {
+        Highcharts.setOptions({
+          time: { useUTC: false },
+          tooltip: { shared: true, xDateFormat: '%e %b %Y %H:%M' }
+        });
+      }
     });
   </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/canvg/3.0.7/umd.min.js" defer></script>


### PR DESCRIPTION
## Summary
- ensure Highcharts uses local time
- share and format tooltips consistently across graphs

## Testing
- `php -l frontend/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5d72c7194832eb11ce6ae11b981fc