### PR TITLE
feat: enable dark theme for tables and charts

### DIFF
--- a/frontend/astro/index.php
+++ b/frontend/astro/index.php
@@ -80,17 +80,17 @@ function thirtyrag($value) {
 }
 
 function getdetail($date, $json) {
-  $html = '<div class="overflow-x-auto"><table class="min-w-full bg-white text-sm"><thead><tr>' .
-    '<th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-left text-sm uppercase font-semibold">Date</th>' .
-    '<th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Total Cloud</th>' .
-    '<th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Combined Index</th>' .
-    '<th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Seeing Index</th>' .
-    '<th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Pickering Index</th>' .
-    '<th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Trans Index</th>' .
-    '<th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Low Cloud</th>' .
-    '<th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Medium Cloud</th>' .
-    '<th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">High Cloud</th>' .
-    '</tr></thead><tbody class="divide-y divide-gray-200">';
+  $html = '<div class="overflow-x-auto"><table class="min-w-full bg-white dark:bg-gray-800 dark:text-gray-100 text-sm"><thead><tr>' .
+    '<th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-left text-sm uppercase font-semibold">Date</th>' .
+    '<th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold">Total Cloud</th>' .
+    '<th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold">Combined Index</th>' .
+    '<th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold">Seeing Index</th>' .
+    '<th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold">Pickering Index</th>' .
+    '<th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold">Trans Index</th>' .
+    '<th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold">Low Cloud</th>' .
+    '<th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold">Medium Cloud</th>' .
+    '<th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold">High Cloud</th>' .
+    '</tr></thead><tbody class="divide-y divide-gray-200 dark:divide-gray-700">';
   foreach ($json['metcheckData']['forecastLocation']['forecast'] as $key => $value) {
     $hourrag = seeingrag($json['metcheckData']['forecastLocation']['forecast'][$key]['seeingIndex']);
     $html .= "<tr class=\"border-l-4 $hourrag\">";
@@ -210,7 +210,7 @@ if(isset($singledate)){
   echo "
 <div class=\"container mx-auto p-4\">
   <h1 class=\"text-2xl font-bold mb-4\">Detail</h1>
-  <div class=\"bg-white shadow rounded p-4 border-l-4 border-$detailcolor\">
+  <div class=\"bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4 border-l-4 border-$detailcolor\">
     <h2 class=\"text-xl font-semibold mb-4\">$singledate</h2>
     $detail
   </div>
@@ -237,7 +237,7 @@ $day=substr($keya,0,10);
 $moon=(Moon::calculateMoonTimes(date('m', strtotime(substr($keya,0,10))),date('d', strtotime(substr($keya,0,10))), date('Y', strtotime(substr($keya,0,10))), 51.8, -0.3));
 $MR=gmdate("H:i", $moon->moonrise);
 $MS=gmdate("H:i", $moon->moonset);
-echo "\n<div class=\"border-l-4 border-$color bg-white shadow rounded p-2\">\n  <a href=\"/astro/index.php?DATE=$day&DATECOLOR=$color\" class=\"block\">\n    <div class=\"flex\">\n      <div class=\"text-$color text-xs mr-2 flex items-center\" style=\"writing-mode: vertical-rl; transform: rotate(180deg);\">$simple</div>\n      <div class=\"flex-1\">\n        <div class=\"flex justify-between\">\n          <div class=\"text-xs font-bold text-gray-900 uppercase mb-1\">$cloud% Cloud<br> $wd</div>\n          <div class=\"text-right\">\n            <div class=\"font-light text-xs text-gray-900\">Night $SS -> $SR</div>\n            <div class=\"font-light text-xs text-gray-500\">Moon $MS -> $MR</div>\n          </div>\n        </div>\n        <div class=\"mt-1\">$graphic</div>\n      </div>\n    </div>\n  </a>\n</div>";
+echo "\n<div class=\"border-l-4 border-$color bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-2\">\n  <a href=\"/astro/index.php?DATE=$day&DATECOLOR=$color\" class=\"block\">\n    <div class=\"flex\">\n      <div class=\"text-$color text-xs mr-2 flex items-center\" style=\"writing-mode: vertical-rl; transform: rotate(180deg);\">$simple</div>\n      <div class=\"flex-1\">\n        <div class=\"flex justify-between\">\n          <div class=\"text-xs font-bold text-gray-900 dark:text-gray-100 uppercase mb-1\">$cloud% Cloud<br> $wd</div>\n          <div class=\"text-right\">\n            <div class=\"font-light text-xs text-gray-900 dark:text-gray-100\">Night $SS -> $SR</div>\n            <div class=\"font-light text-xs text-gray-500 dark:text-gray-400\">Moon $MS -> $MR</div>\n          </div>\n        </div>\n        <div class=\"mt-1\">$graphic</div>\n      </div>\n    </div>\n  </a>\n</div>";
 
 }
 

--- a/frontend/export.php
+++ b/frontend/export.php
@@ -12,9 +12,9 @@ mysqli_free_result($res);
 ?>
 <div>
   <div class="flex flex-col sm:flex-row items-center justify-between mb-2">
-    <h1 class="text-2xl text-gray-800">Export Data</h1>
+    <h1 class="text-2xl text-gray-800 dark:text-gray-100">Export Data</h1>
   </div>
-  <div class="bg-white shadow rounded p-4">
+  <div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4">
     <p class="mb-4">Download weather observations as a gzipped JSON file.</p>
     <div class="mb-4 range-slider">
       <div class="relative h-2">

--- a/frontend/extremes.php
+++ b/frontend/extremes.php
@@ -30,20 +30,20 @@ require_once '../dbconn.php';
 <div class="space-y-6">
   <h1 class="text-2xl font-bold">Extremes</h1>
 
-  <div class="bg-white shadow rounded p-4">
+  <div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4">
     <h2 class="text-xl font-semibold mb-4">Last 24 Hours</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div id="dayChart" class="h-96"></div>
       <div class="overflow-x-auto">
-        <table class="min-w-full bg-white text-sm">
+        <table class="min-w-full bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm">
           <thead>
             <tr>
-              <th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-left text-sm uppercase font-semibold">Metric</th>
-              <th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Max</th>
-              <th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Min</th>
+              <th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-left text-sm uppercase font-semibold">Metric</th>
+              <th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold">Max</th>
+              <th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold">Min</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-gray-200">
+          <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
             <tr><td class="px-4 py-2 text-left">Outside Temp</td><td class="px-4 py-2 text-right"><?php echo $day['outTempMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $day['outTempMin']; ?></td></tr>
             <tr><td class="px-4 py-2 text-left">Inside Temp</td><td class="px-4 py-2 text-right"><?php echo $day['inTempMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $day['inTempMin']; ?></td></tr>
             <tr><td class="px-4 py-2 text-left">Inside Humidity</td><td class="px-4 py-2 text-right"><?php echo $day['inHumMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $day['inHumMin']; ?></td></tr>
@@ -56,20 +56,20 @@ require_once '../dbconn.php';
     </div>
   </div>
 
-  <div class="bg-white shadow rounded p-4">
+  <div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4">
     <h2 class="text-xl font-semibold mb-4">Last 7 Days</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div id="weekChart" class="h-96"></div>
       <div class="overflow-x-auto">
-        <table class="min-w-full bg-white text-sm">
+        <table class="min-w-full bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm">
           <thead>
             <tr>
-              <th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-left text-sm uppercase font-semibold">Metric</th>
-              <th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Max</th>
-              <th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Min</th>
+              <th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-left text-sm uppercase font-semibold">Metric</th>
+              <th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold">Max</th>
+              <th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold">Min</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-gray-200">
+          <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
             <tr><td class="px-4 py-2 text-left">Outside Temp</td><td class="px-4 py-2 text-right"><?php echo $week['outTempMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $week['outTempMin']; ?></td></tr>
             <tr><td class="px-4 py-2 text-left">Inside Temp</td><td class="px-4 py-2 text-right"><?php echo $week['inTempMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $week['inTempMin']; ?></td></tr>
             <tr><td class="px-4 py-2 text-left">Inside Humidity</td><td class="px-4 py-2 text-right"><?php echo $week['inHumMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $week['inHumMin']; ?></td></tr>
@@ -82,20 +82,20 @@ require_once '../dbconn.php';
     </div>
   </div>
 
-  <div class="bg-white shadow rounded p-4">
+  <div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4">
     <h2 class="text-xl font-semibold mb-4">Last Month</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div id="monthChart" class="h-96"></div>
       <div class="overflow-x-auto">
-        <table class="min-w-full bg-white text-sm">
+        <table class="min-w-full bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm">
           <thead>
             <tr>
-              <th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-left text-sm uppercase font-semibold">Metric</th>
-              <th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Max</th>
-              <th class="px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold">Min</th>
+              <th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-left text-sm uppercase font-semibold">Metric</th>
+              <th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold">Max</th>
+              <th class="px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold">Min</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-gray-200">
+          <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
             <tr><td class="px-4 py-2 text-left">Outside Temp</td><td class="px-4 py-2 text-right"><?php echo $month['outTempMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $month['outTempMin']; ?></td></tr>
             <tr><td class="px-4 py-2 text-left">Inside Temp</td><td class="px-4 py-2 text-right"><?php echo $month['inTempMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $month['inTempMin']; ?></td></tr>
             <tr><td class="px-4 py-2 text-left">Inside Humidity</td><td class="px-4 py-2 text-right"><?php echo $month['inHumMax']; ?></td><td class="px-4 py-2 text-right"><?php echo $month['inHumMin']; ?></td></tr>

--- a/frontend/header.php
+++ b/frontend/header.php
@@ -66,6 +66,7 @@ $rainTotal = $row['rainTotal'];
     });
   </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/canvg/3.0.7/umd.min.js" defer></script>
+  <script src="js/chart-theme.js" defer></script>
   <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png">

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -7,15 +7,15 @@ require_once '../dbconn.php';
 
 <div>
   <div class="flex flex-col sm:flex-row items-center justify-between mb-2">
-    <h1 class="text-2xl text-gray-800">Current Conditions</h1>
+    <h1 class="text-2xl text-gray-800 dark:text-gray-100">Current Conditions</h1>
   </div>
   <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-    <div class="bg-white border-l-4 border-red-500 shadow rounded p-4">
+    <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-red-500 shadow rounded p-4">
       <a href="dynamic-graph.php?WHAT=outTemp&SCALE=day" class="block hover:no-underline">
         <div class="flex items-center">
           <div class="flex-grow mr-2">
             <div class="text-[0.525rem] font-bold text-red-500 uppercase mb-1">Outside Temperature</div>
-            <div class="text-xl font-bold text-gray-800"><span id=OutTemp>-</span> &#176;C</div>
+            <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><span id=OutTemp>-</span> &#176;C</div>
           </div>
           <div class="flex-shrink-0">
             <i class="fas fa-temperature-low fa-2x text-gray-300"></i>
@@ -23,12 +23,12 @@ require_once '../dbconn.php';
         </div>
       </a>
     </div>
-    <div class="bg-white border-l-4 border-green-500 shadow rounded p-4">
+    <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-green-500 shadow rounded p-4">
       <a href="dynamic-graph.php?WHAT=outHumidity&SCALE=day" class="block hover:no-underline">
         <div class="flex items-center">
           <div class="flex-grow mr-2">
             <div class="text-[0.525rem] font-bold text-green-500 uppercase mb-1">Outside Humidity</div>
-            <div class="text-xl font-bold text-gray-800"><span id=OutHumidity>-</span> %</div>
+            <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><span id=OutHumidity>-</span> %</div>
           </div>
           <div class="flex-shrink-0">
             <i class="fas fa-bolt fa-2x text-gray-300"></i>
@@ -36,12 +36,12 @@ require_once '../dbconn.php';
         </div>
       </a>
     </div>
-    <div class="bg-white border-l-4 border-cyan-500 shadow rounded p-4">
+    <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-cyan-500 shadow rounded p-4">
       <a href="dynamic-graph.php?WHAT=windSpeed&SCALE=day" class="block hover:no-underline">
         <div class="flex items-center">
           <div class="flex-grow mr-2">
             <div class="text-[0.525rem] font-bold text-cyan-500 uppercase mb-1">Wind Speed</div>
-            <div class="text-xl font-bold text-gray-800"><span id=windSpeed_kph>-</span> kph</div>
+            <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><span id=windSpeed_kph>-</span> kph</div>
           </div>
           <div class="flex-shrink-0">
             <i class="fas fa-wind fa-2x text-gray-300"></i>
@@ -49,12 +49,12 @@ require_once '../dbconn.php';
         </div>
       </a>
     </div>
-    <div class="bg-white border-l-4 border-yellow-500 shadow rounded p-4">
+    <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-yellow-500 shadow rounded p-4">
       <a href="dynamic-graph.php?WHAT=barometer&SCALE=day" class="block hover:no-underline">
         <div class="flex items-center">
           <div class="flex-grow mr-2">
             <div class="text-[0.525rem] font-bold text-yellow-500 uppercase mb-1">Barometer</div>
-            <div class="text-xl font-bold text-gray-800"><span id=Barometer>-</span> mbar</div>
+            <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><span id=Barometer>-</span> mbar</div>
           </div>
           <div class="flex-shrink-0">
             <i class="fas fa-chart-bar fa-2x text-gray-300"></i>
@@ -62,12 +62,12 @@ require_once '../dbconn.php';
         </div>
       </a>
     </div>
-    <div class="bg-white border-l-4 border-purple-500 shadow rounded p-4">
+    <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-purple-500 shadow rounded p-4">
       <a href="dynamic-graph.php?WHAT=dewpoint&SCALE=day" class="block hover:no-underline">
         <div class="flex items-center">
           <div class="flex-grow mr-2">
             <div class="text-[0.525rem] font-bold text-purple-500 uppercase mb-1">Dew Point</div>
-            <div class="text-xl font-bold text-gray-800"><span id=Dewpoint>-</span> &#176;C</div>
+            <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><span id=Dewpoint>-</span> &#176;C</div>
           </div>
           <div class="flex-shrink-0">
             <i class="fas fa-thermometer-half fa-2x text-gray-300"></i>
@@ -75,12 +75,12 @@ require_once '../dbconn.php';
         </div>
       </a>
     </div>
-    <div class="bg-white border-l-4 border-indigo-500 shadow rounded p-4">
+    <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-indigo-500 shadow rounded p-4">
       <a href="dynamic-graph.php?WHAT=windchill&SCALE=day" class="block hover:no-underline">
         <div class="flex items-center">
           <div class="flex-grow mr-2">
             <div class="text-[0.525rem] font-bold text-indigo-500 uppercase mb-1">Wind Chill</div>
-            <div class="text-xl font-bold text-gray-800"><span id=Windchill>-</span> &#176;C</div>
+            <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><span id=Windchill>-</span> &#176;C</div>
           </div>
           <div class="flex-shrink-0">
             <i class="fas fa-snowflake fa-2x text-gray-300"></i>
@@ -88,12 +88,12 @@ require_once '../dbconn.php';
         </div>
       </a>
     </div>
-    <div class="bg-white border-l-4 border-blue-500 shadow rounded p-4">
+    <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-blue-500 shadow rounded p-4">
       <a href="dynamic-graph.php?WHAT=rain&SCALE=day" class="block hover:no-underline">
         <div class="flex items-center">
           <div class="flex-grow mr-2">
             <div class="text-[0.525rem] font-bold text-blue-500 uppercase mb-1">Rain Today</div>
-            <div class="text-xl font-bold text-gray-800"><span id=drain>-</span> cm</div>
+            <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><span id=drain>-</span> cm</div>
           </div>
           <div class="flex-shrink-0">
             <i class="fas fa-tint fa-2x text-gray-300"></i>
@@ -101,12 +101,12 @@ require_once '../dbconn.php';
         </div>
       </a>
     </div>
-    <div class="bg-white border-l-4 border-blue-500 shadow rounded p-4">
+    <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-blue-500 shadow rounded p-4">
       <a href="dynamic-graph.php?WHAT=rain&TYPE=MINMAX&SCALE=month" class="block hover:no-underline">
         <div class="flex items-center">
           <div class="flex-grow mr-2">
             <div class="text-[0.525rem] font-bold text-blue-500 uppercase mb-1">Rain this Month</div>
-            <div class="text-xl font-bold text-gray-800"><span id=mrain>-</span> cm</div>
+            <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><span id=mrain>-</span> cm</div>
           </div>
           <div class="flex-shrink-0">
             <i class="fas fa-tint fa-2x text-gray-300"></i>
@@ -114,12 +114,12 @@ require_once '../dbconn.php';
         </div>
       </a>
     </div>
-    <div class="bg-white border-l-4 border-cyan-500 shadow rounded p-4">
+    <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-cyan-500 shadow rounded p-4">
       <a href="dynamic-graph.php?WHAT=windGust&SCALE=day" class="block hover:no-underline">
         <div class="flex items-center">
           <div class="flex-grow mr-2">
             <div class="text-[0.525rem] font-bold text-cyan-500 uppercase mb-1">Wind Gust</div>
-            <div class="text-xl font-bold text-gray-800">
+            <div class="text-xl font-bold text-gray-800 dark:text-gray-100">
               <span id=windGust_kph>-</span> kph :
               <span id=windGustDir>-</span> Deg
             </div>
@@ -130,12 +130,12 @@ require_once '../dbconn.php';
         </div>
       </a>
     </div>
-    <div class="bg-white border-l-4 border-cyan-500 shadow rounded p-4">
+    <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-cyan-500 shadow rounded p-4">
       <a href="dynamic-graph.php?WHAT=windDir&SCALE=day" class="block hover:no-underline">
         <div class="flex items-center">
           <div class="flex-grow mr-2">
             <div class="text-[0.525rem] font-bold text-cyan-500 uppercase mb-1">Wind Direction</div>
-            <div class="text-xl font-bold text-gray-800"><span id=windDir>-</span> Deg</div>
+            <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><span id=windDir>-</span> Deg</div>
           </div>
           <div class="flex-shrink-0">
             <i class="fas fa-wind fa-2x text-gray-300"></i>
@@ -146,7 +146,7 @@ require_once '../dbconn.php';
   </div>
 
   <div class="mt-4">
-    <div class="bg-white shadow rounded mb-2">
+    <div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded mb-2">
       <div class="px-4 py-3 flex items-center justify-between border-b">
         <h5 class="font-bold text-blue-500">Last 24 hours</h5>
         <a href="overview-graph.php?FULL=1#graph" class="inline-block text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">Full Screen</a>
@@ -161,7 +161,7 @@ require_once '../dbconn.php';
 <div>
   <div class="flex justify-center">
     <div class="w-full md:w-1/2 xl:w-1/3">
-      <div class="bg-white shadow rounded p-4">
+      <div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4">
         <h5 class="text-lg font-semibold">Current Garden View</h5>
         <p class="mb-4">Snap Shot of conditions</p>
         <img src="https://www.smeird.com/images/snap.jpeg" class="w-full h-auto rounded" alt="Card image">

--- a/frontend/js/chart-theme.js
+++ b/frontend/js/chart-theme.js
@@ -1,0 +1,30 @@
+document.addEventListener('DOMContentLoaded', () => {
+  function applyChartTheme() {
+    if (!window.Highcharts) return;
+    const isDark = document.documentElement.classList.contains('dark');
+    const textColor = isDark ? '#f3f4f6' : '#111827';
+    const gridColor = isDark ? '#374151' : '#e5e7eb';
+    const bgColor = isDark ? '#1f2937' : '#ffffff';
+    Highcharts.setOptions({
+      chart: { backgroundColor: bgColor, style: { color: textColor } },
+      title: { style: { color: textColor } },
+      xAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor },
+      yAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor, title: { style: { color: textColor } } },
+      legend: { itemStyle: { color: textColor } }
+    });
+    Highcharts.charts.forEach(chart => {
+      if (chart) {
+        chart.update({
+          chart: { backgroundColor: bgColor },
+          xAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor },
+          yAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor },
+          legend: { itemStyle: { color: textColor } }
+        }, false);
+        chart.redraw();
+      }
+    });
+  }
+  applyChartTheme();
+  const observer = new MutationObserver(applyChartTheme);
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+});

--- a/frontend/last-time.php
+++ b/frontend/last-time.php
@@ -28,11 +28,11 @@ if ($month && $what) {
   mysqli_stmt_close($stmt);
 }
 ?>
-<div class="bg-white shadow rounded p-4 mb-4">
+<div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4 mb-4">
   <form method="get" class="grid grid-cols-1 gap-4 md:grid-cols-3">
     <div>
-      <label for="what" class="block mb-2 text-sm font-medium text-gray-900">Data</label>
-      <select id="what" name="WHAT" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+      <label for="what" class="block mb-2 text-sm font-medium text-gray-900 dark:text-gray-100">Data</label>
+      <select id="what" name="WHAT" class="bg-gray-50 border border-gray-300 text-gray-900 dark:text-gray-100 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500">
         <option value="outTemp">Outside Temperature</option>
         <option value="outHumidity">Outside Humidity</option>
         <option value="windSpeed">Wind Speed</option>
@@ -46,8 +46,8 @@ if ($month && $what) {
       </select>
     </div>
     <div>
-      <label for="month" class="block mb-2 text-sm font-medium text-gray-900">Month</label>
-      <select id="month" name="MONTH" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+      <label for="month" class="block mb-2 text-sm font-medium text-gray-900 dark:text-gray-100">Month</label>
+      <select id="month" name="MONTH" class="bg-gray-50 border border-gray-300 text-gray-900 dark:text-gray-100 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500">
         <option value="1">January</option>
         <option value="2">February</option>
         <option value="3">March</option>
@@ -72,7 +72,7 @@ document.getElementById('what').value = '<?php echo $what ? htmlspecialchars($wh
 document.getElementById('month').value = '<?php echo $month ? htmlspecialchars((string)$month, ENT_QUOTES) : ''; ?>';
 </script>
 <?php if ($month && $what) { ?>
-<div class="bg-white shadow rounded p-4">
+<div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4">
   <div id="lastTimeChart" class="w-full h-96 animate-pulse bg-gray-200 flex items-center justify-center">Loading...</div>
 </div>
 <script>

--- a/frontend/metric-graph.php
+++ b/frontend/metric-graph.php
@@ -27,10 +27,10 @@
  if(isset($_GET['FULL'])) {
  include ('header.php');
  echo "<a class=\"inline-block bg-blue-500 text-white px-4 py-2 rounded\" href=\"index.php?item=$item#graph\">Back</a>
-  <div id=\"largecontainer\" class=\"bg-white shadow rounded p-4\" style=\"height: 100%; min-width: 100%\"></div>";
+  <div id=\"largecontainer\" class=\"bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4\" style=\"height: 100%; min-width: 100%\"></div>";
  } else {
  echo "<p><a class=\"inline-block bg-blue-500 text-white px-4 py-2 rounded\" href=metric-graph.php?FULL=1&item=$item>Click here to open the graph in a seperate page</a></p><div><hr>
- <div id=\"largecontainer\" class=\"bg-white shadow rounded p-4\" style=\"height: 100%;\"></div>
+ <div id=\"largecontainer\" class=\"bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4\" style=\"height: 100%;\"></div>
  ";
 }
 

--- a/frontend/picture.php
+++ b/frontend/picture.php
@@ -6,9 +6,9 @@ include('header.php');
 ?>
 <div>
   <div class="flex flex-col sm:flex-row items-center justify-between mb-2">
-    <h1 class="text-2xl text-gray-800">Webcam</h1>
+    <h1 class="text-2xl text-gray-800 dark:text-gray-100">Webcam</h1>
   </div>
-  <div class="bg-white shadow rounded p-4">
+  <div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4">
     <img src="/images/snap.jpeg?<?php echo time(); ?>" alt="Latest webcam snapshot" class="w-full h-auto rounded">
   </div>
 </div>

--- a/frontend/range-graph.php
+++ b/frontend/range-graph.php
@@ -5,9 +5,9 @@ $gt     = "areasplinerange";
 
 if(isset($_GET['FULL'])) {
  include('header.php');
- echo "<a class=\"inline-block bg-blue-500 text-white px-4 py-2 rounded\" href=\"index.php#graph\">Back</a>\n  <div id=\"container2\" class=\"bg-white shadow rounded p-4\" style=\"height: 800px; min-width: 100%\"></div>";
+ echo "<a class=\"inline-block bg-blue-500 text-white px-4 py-2 rounded\" href=\"index.php#graph\">Back</a>\n  <div id=\"container2\" class=\"bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4\" style=\"height: 800px; min-width: 100%\"></div>";
 } else {
-  echo "<a class=\"inline-block bg-blue-500 text-white px-4 py-2 rounded\" href=range-graph.php?FULL=1&itemmm=$itemmm>Click here for Full Screen</a>\n <div id=\"container2\" class=\"bg-white shadow rounded p-4\" style=\"height: 800px; min-width: 100%\"></div>\n ";
+  echo "<a class=\"inline-block bg-blue-500 text-white px-4 py-2 rounded\" href=range-graph.php?FULL=1&itemmm=$itemmm>Click here for Full Screen</a>\n <div id=\"container2\" class=\"bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4\" style=\"height: 800px; min-width: 100%\"></div>\n ";
 }
 ?>
 

--- a/frontend/records.php
+++ b/frontend/records.php
@@ -83,17 +83,17 @@ mysqli_free_result($resultRainRate);
 
 <div>
   <div class="flex flex-col sm:flex-row items-center justify-between mb-2">
-    <h1 class="text-2xl text-gray-800">Records</h1>
+    <h1 class="text-2xl text-gray-800 dark:text-gray-100">Records</h1>
   </div>
 
     <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
       <a class="block" href="dynamic-graph.php?WHAT=outTemp&SCALE=day&DATE=<?php echo date('Y-m-d', strtotime($hot['dt'])); ?>">
-        <div class="bg-white border-l-4 border-red-500 shadow rounded p-4">
+        <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-red-500 shadow rounded p-4">
           <div class="flex items-center">
             <div class="flex-grow mr-2">
               <div class="text-xs font-bold text-red-500 uppercase mb-1">Hottest Day</div>
-              <div class="text-xl font-bold text-gray-800"><?php echo $hot['temp']; ?> &#8451;</div>
-              <div class="text-sm text-gray-500"><?php echo $hot['dt']; ?></div>
+              <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><?php echo $hot['temp']; ?> &#8451;</div>
+              <div class="text-sm text-gray-500 dark:text-gray-400"><?php echo $hot['dt']; ?></div>
             </div>
             <div class="flex-shrink-0">
               <i class="fas fa-temperature-high fa-2x text-gray-300"></i>
@@ -103,12 +103,12 @@ mysqli_free_result($resultRainRate);
       </a>
 
       <a class="block" href="dynamic-graph.php?WHAT=outTemp&SCALE=day&DATE=<?php echo date('Y-m-d', strtotime($cold['dt'])); ?>">
-        <div class="bg-white border-l-4 border-blue-500 shadow rounded p-4">
+        <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-blue-500 shadow rounded p-4">
           <div class="flex items-center">
             <div class="flex-grow mr-2">
               <div class="text-xs font-bold text-blue-500 uppercase mb-1">Coldest Day</div>
-              <div class="text-xl font-bold text-gray-800"><?php echo $cold['temp']; ?> &#8451;</div>
-              <div class="text-sm text-gray-500"><?php echo $cold['dt']; ?></div>
+              <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><?php echo $cold['temp']; ?> &#8451;</div>
+              <div class="text-sm text-gray-500 dark:text-gray-400"><?php echo $cold['dt']; ?></div>
             </div>
             <div class="flex-shrink-0">
               <i class="fas fa-temperature-low fa-2x text-gray-300"></i>
@@ -117,11 +117,11 @@ mysqli_free_result($resultRainRate);
         </div>
       </a>
 
-    <div class="bg-white border-l-4 border-yellow-500 shadow rounded p-4">
+    <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-yellow-500 shadow rounded p-4">
       <div class="flex items-center">
         <div class="flex-grow mr-2">
           <div class="text-xs font-bold text-yellow-500 uppercase mb-1">Days &gt; 35&#8451;</div>
-          <div class="text-xl font-bold text-gray-800"><?php echo $daysOver35; ?></div>
+          <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><?php echo $daysOver35; ?></div>
         </div>
         <div class="flex-shrink-0">
           <i class="fas fa-sun fa-2x text-gray-300"></i>
@@ -129,11 +129,11 @@ mysqli_free_result($resultRainRate);
       </div>
     </div>
 
-    <div class="bg-white border-l-4 border-cyan-500 shadow rounded p-4">
+    <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-cyan-500 shadow rounded p-4">
       <div class="flex items-center">
         <div class="flex-grow mr-2">
           <div class="text-xs font-bold text-cyan-500 uppercase mb-1">Days &lt; -5&#8451;</div>
-          <div class="text-xl font-bold text-gray-800"><?php echo $daysUnderMinus5; ?></div>
+          <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><?php echo $daysUnderMinus5; ?></div>
         </div>
         <div class="flex-shrink-0">
           <i class="fas fa-snowflake fa-2x text-gray-300"></i>
@@ -142,12 +142,12 @@ mysqli_free_result($resultRainRate);
     </div>
 
       <a class="block" href="dynamic-graph.php?WHAT=windGust&SCALE=day&DATE=<?php echo date('Y-m-d', strtotime($gust['dt'])); ?>">
-        <div class="bg-white border-l-4 border-green-500 shadow rounded p-4">
+        <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-green-500 shadow rounded p-4">
           <div class="flex items-center">
             <div class="flex-grow mr-2">
               <div class="text-xs font-bold text-green-500 uppercase mb-1">Highest Wind Gust</div>
-              <div class="text-xl font-bold text-gray-800"><?php echo $gust['gust']; ?> m/s</div>
-              <div class="text-sm text-gray-500"><?php echo $gust['dt']; ?></div>
+              <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><?php echo $gust['gust']; ?> m/s</div>
+              <div class="text-sm text-gray-500 dark:text-gray-400"><?php echo $gust['dt']; ?></div>
             </div>
             <div class="flex-shrink-0">
               <i class="fas fa-wind fa-2x text-gray-300"></i>
@@ -157,12 +157,12 @@ mysqli_free_result($resultRainRate);
       </a>
 
       <a class="block" href="dynamic-graph.php?WHAT=rainRate&SCALE=day&DATE=<?php echo date('Y-m-d', strtotime($rainRate['dt'])); ?>">
-        <div class="bg-white border-l-4 border-indigo-500 shadow rounded p-4">
+        <div class="bg-white dark:bg-gray-800 dark:text-gray-100 border-l-4 border-indigo-500 shadow rounded p-4">
           <div class="flex items-center">
             <div class="flex-grow mr-2">
               <div class="text-xs font-bold text-indigo-500 uppercase mb-1">Highest Rain Rate</div>
-              <div class="text-xl font-bold text-gray-800"><?php echo $rainRate['rate']; ?> mm/h</div>
-              <div class="text-sm text-gray-500"><?php echo $rainRate['dt']; ?></div>
+              <div class="text-xl font-bold text-gray-800 dark:text-gray-100"><?php echo $rainRate['rate']; ?> mm/h</div>
+              <div class="text-sm text-gray-500 dark:text-gray-400"><?php echo $rainRate['dt']; ?></div>
             </div>
             <div class="flex-shrink-0">
               <i class="fas fa-cloud-showers-heavy fa-2x text-gray-300"></i>

--- a/frontend/report.php
+++ b/frontend/report.php
@@ -84,21 +84,21 @@ while ($row = mysqli_fetch_assoc($result)) {
 mysqli_free_result($result);
 
 // Generate the HTML table
-echo "<table class=\"min-w-full bg-white text-sm\">";
+echo "<table class=\"min-w-full bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm\">";
 echo "<thead>\n";
 echo "  <tr>\n";
-echo "    <th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-left text-sm uppercase font-semibold\" rowspan=\"2\">YR</th>\n";
-echo "    <th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-left text-sm uppercase font-semibold\" rowspan=\"2\">MO</th>\n";
-echo "    <th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold\" rowspan=\"2\">TOTAL</th>\n";
-echo "    <th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold\" rowspan=\"2\">MAX DAY</th>\n";
-echo "    <th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-center text-sm uppercase font-semibold\" colspan=\"3\">Days Over</th>\n";
+echo "    <th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-left text-sm uppercase font-semibold\" rowspan=\"2\">YR</th>\n";
+echo "    <th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-left text-sm uppercase font-semibold\" rowspan=\"2\">MO</th>\n";
+echo "    <th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold\" rowspan=\"2\">TOTAL</th>\n";
+echo "    <th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold\" rowspan=\"2\">MAX DAY</th>\n";
+echo "    <th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-center text-sm uppercase font-semibold\" colspan=\"3\">Days Over</th>\n";
 echo "  </tr>\n";
 echo "  <tr>\n";
-echo "    <th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-center text-sm uppercase font-semibold\">0.03</th>\n";
-echo "    <th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-center text-sm uppercase font-semibold\">0.30</th>\n";
-echo "    <th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-center text-sm uppercase font-semibold\">3.00</th>\n";
+echo "    <th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-center text-sm uppercase font-semibold\">0.03</th>\n";
+echo "    <th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-center text-sm uppercase font-semibold\">0.30</th>\n";
+echo "    <th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-center text-sm uppercase font-semibold\">3.00</th>\n";
 echo "  </tr>\n";
-echo "</thead><tbody class=\"divide-y divide-gray-200\">";
+echo "</thead><tbody class=\"divide-y divide-gray-200 dark:divide-gray-700\">";
 
 for ($month = 1; $month <= 12; $month++) {
     if (isset($monthly_data[$month])) {

--- a/frontend/reportrainyeartotals.php
+++ b/frontend/reportrainyeartotals.php
@@ -3,7 +3,7 @@ include('header.php');
 require_once '../dbconn.php';
 
 echo "<div class=\"container mx-auto p-4\">\n";
-echo "  <div class=\"bg-white shadow rounded p-4\">\n";
+echo "  <div class=\"bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4\">\n";
 echo "    <h1 class=\"text-xl font-bold mb-4\">Rain by Year</h1>\n";
 echo "    <div class=\"overflow-x-auto\">\n";
 
@@ -83,16 +83,16 @@ sort($years);
 sort($months);
 
 // Generate the HTML table
-echo "        <table class=\"min-w-full bg-white\">\n";
+echo "        <table class=\"min-w-full bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100\">\n";
 echo "          <thead>\n";
 echo "          <tr>\n";
-echo "            <th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-left text-sm uppercase font-semibold\">Month</th>";
+echo "            <th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-left text-sm uppercase font-semibold\">Month</th>";
 
 foreach ($years as $year) {
-    echo "            <th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold\">$year</th>";
+    echo "            <th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold\">$year</th>";
 }
 
-echo "          </tr>\n          </thead>\n          <tbody class=\"divide-y divide-gray-200\">";
+echo "          </tr>\n          </thead>\n          <tbody class=\"divide-y divide-gray-200 dark:divide-gray-700\">";
 
 // Table rows for each month
 foreach ($months as $month) {

--- a/frontend/reporttempyeartotals.php
+++ b/frontend/reporttempyeartotals.php
@@ -3,7 +3,7 @@ include('header.php');
 require_once '../dbconn.php';
 
 echo "<div class=\"container mx-auto p-4\">\n";
-echo "  <div class=\"bg-white shadow rounded p-4\">\n";
+echo "  <div class=\"bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4\">\n";
 echo "    <h1 class=\"text-xl font-bold mb-4\">Monthly Outside Temperature Comparison (°C)</h1>\n";
 echo "    <div class=\"overflow-x-auto\">\n";
 
@@ -102,24 +102,24 @@ mysqli_free_result($result);
 sort($years);
 
 // Generate the HTML table
-echo "        <table class=\"min-w-full bg-white text-sm\">\n";
+echo "        <table class=\"min-w-full bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm\">\n";
 echo "          <thead>\n";
 echo "          <tr>\n";
-echo "            <th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-left text-sm uppercase font-semibold\" rowspan=\"2\">Month</th>";
+echo "            <th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-left text-sm uppercase font-semibold\" rowspan=\"2\">Month</th>";
 
 // Header cells for each year
 foreach ($years as $year) {
-  echo '            <th class="px-4 py-2 text-gray-600 text-center text-sm uppercase font-semibold" colspan="3">' . $year . '</th>';
+  echo '            <th class="px-4 py-2 text-gray-600 dark:text-gray-300 text-center text-sm uppercase font-semibold" colspan="3">' . $year . '</th>';
 }
 
 echo "          </tr>\n";
 echo "          <tr>";
 foreach ($years as $year) {
-  echo '            <th class="px-4 py-2 text-gray-600 text-center text-sm uppercase font-semibold">Avg</th>' .
-       '<th class="px-4 py-2 text-gray-600 text-center text-sm uppercase font-semibold">Max</th>' .
-       '<th class="px-4 py-2 text-gray-600 text-center text-sm uppercase font-semibold">Min</th>';
+  echo '            <th class="px-4 py-2 text-gray-600 dark:text-gray-300 text-center text-sm uppercase font-semibold">Avg</th>' .
+       '<th class="px-4 py-2 text-gray-600 dark:text-gray-300 text-center text-sm uppercase font-semibold">Max</th>' .
+       '<th class="px-4 py-2 text-gray-600 dark:text-gray-300 text-center text-sm uppercase font-semibold">Min</th>';
 }
-echo "          </tr>\n          </thead>\n          <tbody class=\"divide-y divide-gray-200\">";
+echo "          </tr>\n          </thead>\n          <tbody class=\"divide-y divide-gray-200 dark:divide-gray-700\">";
 
 // Table rows for each month
 foreach ($months as $month) {
@@ -163,7 +163,7 @@ foreach ($months as $month) {
 }
 
 // Add row for yearly averages
-echo "          <tr class=\"font-semibold bg-gray-100\">\n";
+echo "          <tr class=\"font-semibold bg-gray-100 dark:bg-gray-700\">\n";
 echo "            <td class=\"px-4 py-2 text-left\">Average</td>\n";
 foreach ($years as $year) {
   if (isset($yearly_avg_sum[$year]) && $yearly_avg_count[$year] > 0) {

--- a/frontend/reportwindyeartotals.php
+++ b/frontend/reportwindyeartotals.php
@@ -3,7 +3,7 @@ include('header.php');
 require_once '../dbconn.php';
 
 echo "<div class=\"container mx-auto p-4\">\n";
-echo "  <div class=\"bg-white shadow rounded p-4\">\n";
+echo "  <div class=\"bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4\">\n";
 echo "    <h1 class=\"text-xl font-bold mb-4\">Monthly Wind Data Comparison</h1>\n";
 echo "    <div class=\"overflow-x-auto\">\n";
 
@@ -109,25 +109,25 @@ mysqli_free_result($result);
 sort($years);
 
 // Generate the HTML table
-echo "        <table class=\"min-w-full bg-white text-sm\">\n";
+echo "        <table class=\"min-w-full bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm\">\n";
 echo "          <thead>\n";
 echo "          <tr>\n";
-echo "            <th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-left text-sm uppercase font-semibold\" rowspan=\"2\">Month</th>";
+echo "            <th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-left text-sm uppercase font-semibold\" rowspan=\"2\">Month</th>";
 
 foreach ($years as $year) {
-  echo '            <th class="px-4 py-2 text-gray-600 text-center text-sm uppercase font-semibold" colspan="3">' . $year . '</th>';
+  echo '            <th class="px-4 py-2 text-gray-600 dark:text-gray-300 text-center text-sm uppercase font-semibold" colspan="3">' . $year . '</th>';
 }
 
 echo "          </tr>\n";
 echo "          <tr>";
 foreach ($years as $year) {
-  echo '            <th class="px-4 py-2 text-gray-600 text-center text-sm uppercase font-semibold">Avg</th>' .
-       '<th class="px-4 py-2 text-gray-600 text-center text-sm uppercase font-semibold">Max</th>' .
-       '<th class="px-4 py-2 text-gray-600 text-center text-sm uppercase font-semibold">Dir</th>';
+  echo '            <th class="px-4 py-2 text-gray-600 dark:text-gray-300 text-center text-sm uppercase font-semibold">Avg</th>' .
+       '<th class="px-4 py-2 text-gray-600 dark:text-gray-300 text-center text-sm uppercase font-semibold">Max</th>' .
+       '<th class="px-4 py-2 text-gray-600 dark:text-gray-300 text-center text-sm uppercase font-semibold">Dir</th>';
 }
 echo "          </tr>\n";
 echo "          </thead>\n";
-echo "          <tbody class=\"divide-y divide-gray-200\">\n";
+echo "          <tbody class=\"divide-y divide-gray-200 dark:divide-gray-700\">\n";
 
 // Table rows for each month
 foreach ($months as $month) {

--- a/frontend/seasonal.php
+++ b/frontend/seasonal.php
@@ -1,11 +1,11 @@
 <?php include('header.php'); ?>
-<div class="bg-white shadow rounded p-4">
+<div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4">
   <h2 class="text-xl font-bold mb-4">Seasonal Patterns</h2>
 
   <div class="mb-4 flex flex-wrap gap-4">
     <div class="flex items-center gap-2">
       <label for="type-select">Type:</label>
-      <select id="type-select" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+      <select id="type-select" class="bg-gray-50 dark:bg-gray-700 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
         <option value="temp">Temperature</option>
         <option value="rain">Rain</option>
       </select>
@@ -27,7 +27,7 @@
 
   </div>
   <div id="seasonal-chart" class="mb-4"></div>
-  <table class="min-w-full divide-y divide-gray-200">
+  <table class="min-w-full bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 divide-y divide-gray-200 dark:divide-gray-700">
     <thead class="bg-gray-50">
       <tr>
         <th class="px-4 py-2 text-left">Year</th>
@@ -35,7 +35,7 @@
         <th id="value-header" class="px-4 py-2 text-left"></th>
       </tr>
     </thead>
-    <tbody id="seasonal-table" class="bg-white divide-y divide-gray-200"></tbody>
+    <tbody id="seasonal-table" class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700"></tbody>
   </table>
 </div>
 <script>

--- a/frontend/windrose.php
+++ b/frontend/windrose.php
@@ -12,9 +12,9 @@
 ?>
 <div>
   <div class="flex flex-col sm:flex-row items-center justify-between mb-2">
-    <h1 class="text-2xl text-gray-800">Wind Rose</h1>
+    <h1 class="text-2xl text-gray-800 dark:text-gray-100">Wind Rose</h1>
   </div>
-  <div class="bg-white shadow rounded p-4 mb-3">
+  <div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4 mb-3">
     <p class="mb-2">Select Time Scales</p>
     <form action="/windrose.php" method="POST" class="flex items-center space-x-2">
       <label class="flex items-center">
@@ -29,7 +29,7 @@
       <input class="btn" type="submit" value="Select Date">
     </form>
   </div>
-  <div class="bg-white shadow rounded p-4 mb-3">
+  <div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4 mb-3">
     <div id="container2"></div>
   </div>
 <?php
@@ -47,16 +47,16 @@ $sql = "SELECT
   ORDER BY dir_index";
   $result = db_query($sql);
 
-  echo "<div class=\"bg-white shadow rounded p-4 mb-3\">";
+  echo "<div class=\"bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4 mb-3\">";
   echo "<div class=\"overflow-x-auto\">";
-  echo "<table id=\"freqq\" class=\"min-w-full bg-white text-sm text-center\">";
+  echo "<table id=\"freqq\" class=\"min-w-full bg-white dark:bg-gray-800 dark:text-gray-100 text-sm text-center\">";
   echo "<thead><tr>";
-  echo "<th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-left text-sm uppercase font-semibold\">Direction</th>";
-  echo "<th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold\">&ge;3&nbsp;m/s</th>";
-  echo "<th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold\">2–3&nbsp;m/s</th>";
-  echo "<th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold\">1–2&nbsp;m/s</th>";
-  echo "<th class=\"px-4 py-2 text-gray-600 border-b border-gray-300 text-right text-sm uppercase font-semibold\">0–1&nbsp;m/s</th>";
-  echo "</tr></thead><tbody class=\"divide-y divide-gray-200\">";
+  echo "<th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-left text-sm uppercase font-semibold\">Direction</th>";
+  echo "<th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold\">&ge;3&nbsp;m/s</th>";
+  echo "<th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold\">2–3&nbsp;m/s</th>";
+  echo "<th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold\">1–2&nbsp;m/s</th>";
+  echo "<th class=\"px-4 py-2 text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600 text-right text-sm uppercase font-semibold\">0–1&nbsp;m/s</th>";
+  echo "</tr></thead><tbody class=\"divide-y divide-gray-200 dark:divide-gray-700\">";
 
   $dirs = ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW'];
   $data = array_fill(0, 16, ['A' => 0, 'B' => 0, 'C' => 0, 'D' => 0]);


### PR DESCRIPTION
## Summary
- Add global Highcharts dark mode handling and update on theme changes
- Apply Tailwind dark classes across tables and cards
- Include dark-aware styling for record, export, and graph pages

## Testing
- `php -l frontend/header.php frontend/reportrainyeartotals.php frontend/windrose.php frontend/seasonal.php frontend/reporttempyeartotals.php frontend/reportwindyeartotals.php frontend/astro/index.php frontend/report.php frontend/extremes.php frontend/records.php frontend/picture.php frontend/index.php frontend/last-time.php frontend/range-graph.php frontend/metric-graph.php frontend/export.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5d79ffb00832ea87371a9044306ab