### PR TITLE
Add average range graph option

### DIFF
--- a/frontend/dynamic-graph.php
+++ b/frontend/dynamic-graph.php
@@ -45,6 +45,8 @@ if ($date && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
 
 $label = $conditions[$what] ?? $what;
 
+$calc = 'AVG';
+
 switch ($what) {
     case "rain":
         $gt = "column";
@@ -181,7 +183,7 @@ $timesql = "FLOOR(dateTime/$interval)*$interval";
 
     case "MINMAX":
 
-        $sql = "select $timesql * 1000 as datetime, round($calc($what),1) * ? as dataavg, round(MIN($what),1) as datamin, round(MAX($what),1) as datamax FROM weewx.archive $scalesql  $groupby  ORDER BY datetime ASC";
+        $sql = "select $timesql * 1000 as datetime, round(AVG($what),1) * ? as dataavg, round(MIN($what),1) as datamin, round(MAX($what),1) as datamax FROM weewx.archive $scalesql  $groupby  ORDER BY datetime ASC";
         $stmt = mysqli_prepare($link, $sql);
         mysqli_stmt_bind_param($stmt, 'd', $units);
         mysqli_stmt_execute($stmt);
@@ -202,9 +204,7 @@ $timesql = "FLOOR(dateTime/$interval)*$interval";
 
     case "AVG":
 
-
-        $sql = "select $timesql * 1000 as datetime, round($calc($what),1) * ? as dataavg, round(MIN($what),1) as datamin, round(MAX($what),1) as datamax FROM weewx.archive $scalesql  $groupby  ORDER BY datetime ASC";
-
+        $sql = "select $timesql * 1000 as datetime, round(AVG($what),1) * ? as dataavg, round(MIN($what),1) as datamin, round(MAX($what),1) as datamax FROM weewx.archive $scalesql  $groupby  ORDER BY datetime ASC";
         $stmt = mysqli_prepare($link, $sql);
         mysqli_stmt_bind_param($stmt, 'd', $units);
         mysqli_stmt_execute($stmt);


### PR DESCRIPTION
## Summary
- Extend graph selector with new **Average Range** option
- Support `AVG` graph type to render min/max area with average line
- Ensure average range graph uses AVG aggregation for min/max and avg cases

## Testing
- `php -l frontend/dynamic-graph.php`
- `php -l frontend/graph-selector.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5f63e25b4832ea1327dc0b1a909a5