### PR TITLE
Add dark mode styling for tables and charts

### DIFF
--- a/frontend/js/chart-theme.js
+++ b/frontend/js/chart-theme.js
@@ -5,24 +5,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const textColor = isDark ? '#f3f4f6' : '#111827';
     const gridColor = isDark ? '#374151' : '#e5e7eb';
     const bgColor = isDark ? '#1f2937' : '#ffffff';
-    Highcharts.setOptions({
+    const opts = {
       chart: { backgroundColor: bgColor, style: { color: textColor } },
       title: { style: { color: textColor } },
       xAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor },
       yAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor, title: { style: { color: textColor } } },
       legend: { itemStyle: { color: textColor } }
-    });
-    Highcharts.charts.forEach(chart => {
-      if (chart) {
-        chart.update({
-          chart: { backgroundColor: bgColor },
-          xAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor },
-          yAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor },
-          legend: { itemStyle: { color: textColor } }
-        }, false);
-        chart.redraw();
-      }
-    });
+    };
+    Highcharts.setOptions(opts);
+    if (Highcharts.charts) {
+      Highcharts.charts.forEach(chart => {
+        if (chart) {
+          chart.update(opts, false);
+          chart.redraw();
+        }
+      });
+    }
   }
   applyChartTheme();
   const observer = new MutationObserver(applyChartTheme);


### PR DESCRIPTION
## Summary
- Apply theme options to existing Highcharts instances when switching between light and dark modes

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5f67fa39c832ea3dc2d8dbdf862ec