### PR TITLE
Seed initial range in historical explorer to load data

### DIFF
--- a/frontend/historical.php
+++ b/frontend/historical.php
@@ -69,7 +69,7 @@ include('header.php');
 
       let start = Math.round(extremes.min);
       let end = Math.round(extremes.max);
-      if (!isFinite(start) || !isFinite(end)) {
+      if (!isFinite(start) || !isFinite(end) || (start === 0 && end === 1)) {
         end = Date.now();
         start = end - 30 * 24 * 3600 * 1000;
         chart.xAxis[0].setExtremes(start, end, false);
@@ -102,7 +102,9 @@ include('header.php');
         }
       });
     }
-    updateSeries();
+    const initEnd = Date.now();
+    const initStart = initEnd - 30 * 24 * 3600 * 1000;
+    chart.xAxis[0].setExtremes(initStart, initEnd, false);
   });
 </script>
 <?php include('footer.php'); ?>


### PR DESCRIPTION
## Summary
- initialize historical chart with last 30 days
- avoid empty range requests by validating axis extremes

## Testing
- `php -l frontend/historical.php`
- `php -l frontend/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68baba258f00832e9bdcfc256f3f513f