### PR TITLE
Limit historical view to one month by default

### DIFF
--- a/frontend/backend/range-limits.php
+++ b/frontend/backend/range-limits.php
@@ -1,0 +1,15 @@
+<?php
+require_once '../../dbconn.php';
+
+$sql = 'SELECT MIN(dateTime) AS minTime, MAX(dateTime) AS maxTime FROM archive';
+$result = db_query($sql);
+$row = mysqli_fetch_assoc($result);
+mysqli_free_result($result);
+
+$range = [
+  'min' => ((int)$row['minTime']) * 1000,
+  'max' => ((int)$row['maxTime']) * 1000
+];
+
+header('Content-Type: application/json');
+echo json_encode($range);


### PR DESCRIPTION
## Summary
- expose full data range via new `range-limits.php` endpoint
- load one month of history initially while allowing navigation through all available data

## Testing
- `php -l frontend/historical.php`
- `php -l frontend/backend/range-limits.php`


------
https://chatgpt.com/codex/tasks/task_e_68babeb51c30832eaef4998a9cfedbaa