### PR TITLE
Add year selector and dark theme support to climate analysis

### DIFF
--- a/frontend/backend/climate-analysis.php
+++ b/frontend/backend/climate-analysis.php
@@ -4,8 +4,9 @@ require_once __DIR__ . '/../../dbconn.php';
 /**
  * Calculate basic temperature statistics.
  */
-function temperature_stats() {
-  $sql = "SELECT AVG(outTemp) AS mean, MIN(outTemp) AS min, MAX(outTemp) AS max FROM archive";
+function temperature_stats(int $year) {
+  $sql = "SELECT AVG(outTemp) AS mean, MIN(outTemp) AS min, MAX(outTemp) AS max FROM archive
+    WHERE YEAR(FROM_UNIXTIME(dateTime)) = $year";
   $res = db_query($sql);
   $row = mysqli_fetch_assoc($res);
 
@@ -14,7 +15,8 @@ function temperature_stats() {
       AVG(CASE WHEN MONTH(FROM_UNIXTIME(dateTime)) IN (3,4,5) THEN outTemp END) AS spring,
       AVG(CASE WHEN MONTH(FROM_UNIXTIME(dateTime)) IN (6,7,8) THEN outTemp END) AS summer,
       AVG(CASE WHEN MONTH(FROM_UNIXTIME(dateTime)) IN (9,10,11) THEN outTemp END) AS autumn
-    FROM archive";
+    FROM archive
+    WHERE YEAR(FROM_UNIXTIME(dateTime)) = $year";
   $seasonal = mysqli_fetch_assoc(db_query($seasonalSql));
   $row['seasonal_averages'] = $seasonal;
   return $row;
@@ -23,7 +25,7 @@ function temperature_stats() {
 /**
  * Calculate basic rainfall statistics.
  */
-function rainfall_stats() {
+function rainfall_stats(int $year) {
   $sql = "SELECT SUM(daily_rain) AS total,
       SUM(CASE WHEN daily_rain >= 0.1 THEN 1 ELSE 0 END) AS rain_days,
       SUM(CASE WHEN daily_rain >= 1 THEN 1 ELSE 0 END) AS wet_days,
@@ -33,6 +35,7 @@ function rainfall_stats() {
       SELECT DATE(FROM_UNIXTIME(dateTime)) AS day,
              SUM(rain) AS daily_rain
       FROM archive
+      WHERE YEAR(FROM_UNIXTIME(dateTime)) = $year
       GROUP BY day
     ) d";
   $row = mysqli_fetch_assoc(db_query($sql));
@@ -42,25 +45,29 @@ function rainfall_stats() {
 /**
  * Calculate humidity statistics.
  */
-function humidity_stats() {
+function humidity_stats(int $year) {
   $sql = "SELECT AVG(outHumidity) AS mean, MIN(outHumidity) AS min, MAX(outHumidity) AS max,
       SUM(CASE WHEN outHumidity > 90 THEN 1 ELSE 0 END) AS days_gt_90,
       SUM(CASE WHEN outHumidity < 30 THEN 1 ELSE 0 END) AS days_lt_30
-    FROM archive";
+    FROM archive
+    WHERE YEAR(FROM_UNIXTIME(dateTime)) = $year";
   return mysqli_fetch_assoc(db_query($sql));
 }
 
 /**
  * Calculate wind statistics.
  */
-function wind_stats() {
+function wind_stats(int $year) {
   $sql = "SELECT AVG(windSpeed) AS mean_speed,
       MAX(windGust) AS max_gust,
       SUM(CASE WHEN windSpeed < 0.5 THEN 1 ELSE 0 END) / COUNT(*) AS calm_frequency
-    FROM archive";
+    FROM archive
+    WHERE YEAR(FROM_UNIXTIME(dateTime)) = $year";
   $row = mysqli_fetch_assoc(db_query($sql));
 
-  $dirSql = "SELECT windDir, COUNT(*) AS cnt FROM archive GROUP BY windDir ORDER BY cnt DESC LIMIT 1";
+  $dirSql = "SELECT windDir, COUNT(*) AS cnt FROM archive
+    WHERE YEAR(FROM_UNIXTIME(dateTime)) = $year
+    GROUP BY windDir ORDER BY cnt DESC LIMIT 1";
   $dir = mysqli_fetch_assoc(db_query($dirSql));
   $row['prevailing_direction'] = $dir ? $dir['windDir'] : null;
   return $row;
@@ -69,7 +76,7 @@ function wind_stats() {
 /**
  * Compute derived indices like heat index and wind chill.
  */
-function derived_indices_stats() {
+function derived_indices_stats(int $year) {
   $sql = "SELECT AVG(
       -42.379 + 2.04901523*(outTemp*9/5+32) + 10.14333127*outHumidity
       - 0.22475541*(outTemp*9/5+32)*outHumidity
@@ -80,7 +87,8 @@ function derived_indices_stats() {
       - 0.00000199*(outTemp*9/5+32)*(outTemp*9/5+32)*outHumidity*outHumidity
     ) AS heat_index_f,
     AVG(13.12 + 0.6215*outTemp - 11.37*POW(windSpeed*3.6,0.16) + 0.3965*outTemp*POW(windSpeed*3.6,0.16)) AS wind_chill_c
-    FROM archive";
+    FROM archive
+    WHERE YEAR(FROM_UNIXTIME(dateTime)) = $year";
   $row = mysqli_fetch_assoc(db_query($sql));
   return $row;
 }
@@ -88,12 +96,12 @@ function derived_indices_stats() {
 /**
  * Produce monthly climate summaries for the current year.
  */
-function climatological_summaries() {
+function climatological_summaries(int $year) {
   $sql = "SELECT DATE_FORMAT(FROM_UNIXTIME(dateTime),'%m') AS month,
       AVG(outTemp) AS mean_temp,
       SUM(rain) AS total_rain
     FROM archive
-    WHERE YEAR(FROM_UNIXTIME(dateTime)) = YEAR(CURDATE())
+    WHERE YEAR(FROM_UNIXTIME(dateTime)) = $year
     GROUP BY month
     ORDER BY month";
   $res = db_query($sql);
@@ -107,35 +115,37 @@ function climatological_summaries() {
 /**
  * Estimate extreme value statistics.
  */
-function extreme_value_stats() {
-  $cntRow = mysqli_fetch_assoc(db_query("SELECT COUNT(*) AS cnt FROM archive WHERE rain IS NOT NULL"));
+function extreme_value_stats(int $year) {
+  $cntRow = mysqli_fetch_assoc(db_query("SELECT COUNT(*) AS cnt FROM archive WHERE rain IS NOT NULL AND YEAR(FROM_UNIXTIME(dateTime)) = $year"));
   $count = (int) $cntRow['cnt'];
   $rain_p95 = null;
   if ($count > 0) {
     $offset = (int) floor(0.95 * ($count - 1));
-    $rainRow = mysqli_fetch_assoc(db_query("SELECT rain FROM archive WHERE rain IS NOT NULL ORDER BY rain LIMIT 1 OFFSET $offset"));
+    $rainRow = mysqli_fetch_assoc(db_query("SELECT rain FROM archive WHERE rain IS NOT NULL AND YEAR(FROM_UNIXTIME(dateTime)) = $year ORDER BY rain LIMIT 1 OFFSET $offset"));
     $rain_p95 = $rainRow ? (float) $rainRow['rain'] : null;
   }
-  $gustRow = mysqli_fetch_assoc(db_query("SELECT MAX(windGust) AS max_gust FROM archive"));
+  $gustRow = mysqli_fetch_assoc(db_query("SELECT MAX(windGust) AS max_gust FROM archive WHERE YEAR(FROM_UNIXTIME(dateTime)) = $year"));
   return ['rain_p95' => $rain_p95, 'max_gust' => $gustRow['max_gust']];
 }
 
 /**
  * Gather all climate analysis metrics.
  */
-function get_climate_analysis() {
+function get_climate_analysis(?int $year = null) {
+  $year = $year ?: (int) date('Y');
   return [
-    'temperature' => temperature_stats(),
-    'rainfall' => rainfall_stats(),
-    'humidity' => humidity_stats(),
-    'wind' => wind_stats(),
-    'derived_indices' => derived_indices_stats(),
-    'climatological_summaries' => climatological_summaries(),
-    'extreme_value_statistics' => extreme_value_stats(),
+    'temperature' => temperature_stats($year),
+    'rainfall' => rainfall_stats($year),
+    'humidity' => humidity_stats($year),
+    'wind' => wind_stats($year),
+    'derived_indices' => derived_indices_stats($year),
+    'climatological_summaries' => climatological_summaries($year),
+    'extreme_value_statistics' => extreme_value_stats($year),
   ];
 }
 
 if (php_sapi_name() !== 'cli' && empty(debug_backtrace())) {
   header('Content-Type: application/json');
-  echo json_encode(get_climate_analysis());
+  $year = isset($_GET['year']) ? (int) $_GET['year'] : (int) date('Y');
+  echo json_encode(get_climate_analysis($year));
 }

--- a/frontend/climate-analysis.php
+++ b/frontend/climate-analysis.php
@@ -1,7 +1,14 @@
 <?php
 require_once 'header.php';
 require_once 'backend/climate-analysis.php';
-$data = get_climate_analysis();
+
+$year = isset($_GET['year']) ? (int) $_GET['year'] : (int) date('Y');
+$years = [];
+$res = db_query("SELECT DISTINCT YEAR(FROM_UNIXTIME(dateTime)) AS year FROM archive ORDER BY year DESC");
+while ($row = mysqli_fetch_assoc($res)) {
+  $years[] = (int) $row['year'];
+}
+$data = get_climate_analysis($year);
 
 function format_value($value) {
   if (is_numeric($value)) {
@@ -19,19 +26,28 @@ function format_value($value) {
   return $value !== null && $value !== '' ? $value : '-';
 }
 ?>
-<div id="loading" class="fixed inset-0 flex items-center justify-center bg-white z-50">
+<div id="loading" class="fixed inset-0 flex items-center justify-center bg-white dark:bg-gray-900 z-50">
   <p>Loading climate analysis... <span id="load-time">0.0</span>s</p>
 </div>
 <div id="content" class="hidden">
-  <h2 class="text-xl font-bold mb-4">Climate Analysis</h2>
+  <h2 class="text-xl font-bold mb-4">Climate Analysis for <?php echo $year; ?></h2>
+  <form method="get" class="mb-4 flex items-center space-x-2">
+    <label for="year" class="font-medium">Year</label>
+    <select id="year" name="year" class="p-2 rounded bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100">
+      <?php foreach ($years as $y): ?>
+        <option value="<?php echo $y; ?>" <?php echo $y === $year ? 'selected' : ''; ?>><?php echo $y; ?></option>
+      <?php endforeach; ?>
+    </select>
+    <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded">Go</button>
+  </form>
   <div class="grid gap-4 md:grid-cols-2">
     <?php foreach ($data as $section => $metrics): ?>
-      <div class="bg-white shadow rounded p-4">
+      <div class="bg-white dark:bg-gray-800 shadow rounded p-4">
         <h3 class="text-lg font-semibold mb-2"><?php echo ucwords(str_replace('_', ' ', $section)); ?></h3>
         <table class="min-w-full text-sm">
           <tbody>
             <?php foreach ($metrics as $name => $value): ?>
-              <tr class="border-b">
+              <tr class="border-b border-gray-200 dark:border-gray-700">
                 <td class="p-2 font-medium align-top"><?php echo ucwords(str_replace('_', ' ', $name)); ?></td>
                 <td class="p-2"><?php echo format_value($value); ?></td>
               </tr>


### PR DESCRIPTION
## Summary
- allow climate analysis metrics to be filtered by year
- fix dark theme styles and expose year selector on climate analysis page

## Testing
- `php -l frontend/climate-analysis.php`
- `php -l frontend/backend/climate-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68bac52bef54832eb6d63ce7c3f73a02