### PR TITLE
Add descriptive text for climate analysis metrics

### DIFF
--- a/frontend/climate-analysis.php
+++ b/frontend/climate-analysis.php
@@ -3,6 +3,30 @@ require_once 'header.php';
 require_once 'backend/climate-analysis.php';
 $data = get_climate_analysis();
 
+$descriptions = [
+  'mean' => 'Average temperature in °C.',
+  'min' => 'Lowest temperature in °C.',
+  'max' => 'Highest temperature in °C.',
+  'seasonal_averages' => 'Average temperature for each season.',
+  'total' => 'Total rainfall in millimetres.',
+  'rain_days' => 'Days with at least 0.1 mm of rain.',
+  'wet_days' => 'Days with at least 1 mm of rain.',
+  'heavy_rain_days' => 'Days with at least 10 mm of rain.',
+  'max_daily' => 'Largest single-day rainfall (mm).',
+  'days_gt_90' => 'Number of days with humidity above 90%.',
+  'days_lt_30' => 'Number of days with humidity below 30%.',
+  'mean_speed' => 'Average wind speed in m/s.',
+  'max_gust' => 'Strongest wind gust recorded (m/s).',
+  'calm_frequency' => 'Fraction of observations with wind &lt;0.5 m/s.',
+  'prevailing_direction' => 'Most frequent wind direction (degrees).',
+  'heat_index_f' => 'Average heat index in °F.',
+  'wind_chill_c' => 'Average wind chill in °C.',
+  'climatological_summaries' => 'Monthly mean temperature and total rainfall for the current year.',
+  'mean_temp' => 'Average temperature for the month (°C).',
+  'total_rain' => 'Total rainfall for the month (mm).',
+  'rain_p95' => 'Daily rainfall exceeded only 5% of the time (mm).',
+];
+
 function format_value($value) {
   if (is_numeric($value)) {
     return number_format((float) $value, 1);
@@ -29,11 +53,19 @@ function format_value($value) {
       <div class="bg-white shadow rounded p-4">
         <h3 class="text-lg font-semibold mb-2"><?php echo ucwords(str_replace('_', ' ', $section)); ?></h3>
         <table class="min-w-full text-sm">
+          <thead>
+            <tr class="border-b">
+              <th class="p-2 text-left">Metric</th>
+              <th class="p-2 text-left">Value</th>
+              <th class="p-2 text-left">Description</th>
+            </tr>
+          </thead>
           <tbody>
             <?php foreach ($metrics as $name => $value): ?>
               <tr class="border-b">
                 <td class="p-2 font-medium align-top"><?php echo ucwords(str_replace('_', ' ', $name)); ?></td>
                 <td class="p-2"><?php echo format_value($value); ?></td>
+                <td class="p-2 text-gray-600 dark:text-gray-400"><?php echo $descriptions[$name] ?? '-'; ?></td>
               </tr>
             <?php endforeach; ?>
           </tbody>


### PR DESCRIPTION
## Summary
- Provide detailed descriptions for climate analysis metrics and display them in a new table column
- Clarify meanings of humidity thresholds like "Days Lt30"

## Testing
- `php -l frontend/climate-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68bac584500c832ea572d5deefaaec45