### PR TITLE
Ensure historical chart shows initial month

### DIFF
--- a/frontend/historical.php
+++ b/frontend/historical.php
@@ -112,6 +112,7 @@ include('header.php');
         const initEnd = range.max;
         const initStart = initEnd - 30 * 24 * 3600 * 1000;
         chart.xAxis[0].setExtremes(initStart, initEnd, false);
+        updateSeries();
       });
   });
 </script>


### PR DESCRIPTION
## Summary
- Trigger data fetch for the historical chart after setting initial axis extremes so a month of records displays on load.

## Testing
- `php -l frontend/historical.php`

------
https://chatgpt.com/codex/tasks/task_e_68bac6b1ac60832eb53193562bb60ad1