### PR TITLE
Show daily rain totals in historical data

### DIFF
--- a/frontend/backend/range-data.php
+++ b/frontend/backend/range-data.php
@@ -63,19 +63,30 @@ if ($range < 2 * 24 * 3600 * 1000) {
 
 
 
-$sql    = "select dateTime * 1000 as datetime, round(MIN($itemmm),1) as datamin, round(MAX($itemmm),1) as datamax from $table where dateTime BETWEEN UNIX_TIMESTAMP(?) AND UNIX_TIMESTAMP(?)  GROUP BY hour(FROM_UNIXTIME(dateTime)),day(FROM_UNIXTIME(dateTime)) order by dateTime";
+if ($itemmm === 'rain') {
+  $sql = "select UNIX_TIMESTAMP(date(FROM_UNIXTIME(dateTime))) * 1000 as datetime, round(SUM(rain),1) as total from $table where dateTime BETWEEN UNIX_TIMESTAMP(?) AND UNIX_TIMESTAMP(?) group by date(FROM_UNIXTIME(dateTime)) order by dateTime";
+} else {
+  $sql = "select dateTime * 1000 as datetime, round(MIN($itemmm),1) as datamin, round(MAX($itemmm),1) as datamax from $table where dateTime BETWEEN UNIX_TIMESTAMP(?) AND UNIX_TIMESTAMP(?)  GROUP BY hour(FROM_UNIXTIME(dateTime)),day(FROM_UNIXTIME(dateTime)) order by dateTime";
+}
 $stmt = mysqli_prepare($link, $sql);
 mysqli_stmt_bind_param($stmt, 'ss', $startTime, $endTime);
 mysqli_stmt_execute($stmt);
 $result = mysqli_stmt_get_result($stmt);
 
 $rows = [];
-while ($row  = mysqli_fetch_assoc($result)) {
-  $rows[] = [
-    (int)$row['datetime'],
-    (float)$row['datamin'],
-    (float)$row['datamax']
-  ];
+while ($row = mysqli_fetch_assoc($result)) {
+  if ($itemmm === 'rain') {
+    $rows[] = [
+      (int)$row['datetime'],
+      (float)$row['total']
+    ];
+  } else {
+    $rows[] = [
+      (int)$row['datetime'],
+      (float)$row['datamin'],
+      (float)$row['datamax']
+    ];
+  }
 }
 
 // print it

--- a/frontend/historical.php
+++ b/frontend/historical.php
@@ -14,7 +14,7 @@ include('header.php');
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     const datasets = {
-      rain: { label: 'Rain', item: 'rain', color: '#3b82f6' },
+      rain: { label: 'Rain', item: 'rain', color: '#3b82f6', type: 'column' },
       outTemp: { label: 'Temperature', item: 'outTemp', color: '#ef4444' },
       outHumidity: { label: 'Humidity', item: 'outHumidity', color: '#10b981' },
       windSpeed: { label: 'Wind Speed', item: 'windSpeed', color: '#f59e0b' },
@@ -69,13 +69,16 @@ include('header.php');
         }
         let allTimes = [];
         results.forEach(result => {
-          const sdata = result.data.map(point => [point[0], point[1], point[2]]);
+          const ds = datasets[result.key];
+          const sdata = ds.type === 'column'
+            ? result.data.map(point => [point[0], point[1]])
+            : result.data.map(point => [point[0], point[1], point[2]]);
           allTimes = allTimes.concat(sdata.map(p => p[0]));
           chart.addSeries({
-            type: 'areasplinerange',
-            name: datasets[result.key].label,
+            type: ds.type || 'areasplinerange',
+            name: ds.label,
             data: sdata,
-            color: datasets[result.key].color
+            color: ds.color
           }, false);
         });
         chart.redraw();


### PR DESCRIPTION
## Summary
- Aggregate rainfall by day in backend `range-data.php` and return totals instead of min/max.
- Display rain as a column series on the historical chart and support mixed series types.

## Testing
- `php -l frontend/backend/range-data.php`
- `php -l frontend/historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68bac8365ec4832e9e81c58867f7adbc