### PR TITLE
Show daily rain totals in historical data

### DIFF
--- a/frontend/backend/range-data.php
+++ b/frontend/backend/range-data.php
@@ -41,6 +41,8 @@ require_once '../../dbconn.php';
 $range = $end - $start;
 $startTime = gmstrftime('%Y-%m-%d %H:%M:%S', $start / 1000);
 $endTime = gmstrftime('%Y-%m-%d %H:%M:%S', $end / 1000);
+$startDay = gmstrftime('%Y-%m-%d 00:00:00', floor($start / 86400000) * 86400);
+$endDay = gmstrftime('%Y-%m-%d 23:59:59', ceil($end / 86400000) * 86400 - 1);
 
 // find the right table
 // two days range loads minute data
@@ -65,11 +67,13 @@ if ($range < 2 * 24 * 3600 * 1000) {
 
 if ($itemmm === 'rain') {
   $sql = "select UNIX_TIMESTAMP(date(FROM_UNIXTIME(dateTime))) * 1000 as datetime, round(SUM(rain),1) as total from $table where dateTime BETWEEN UNIX_TIMESTAMP(?) AND UNIX_TIMESTAMP(?) group by date(FROM_UNIXTIME(dateTime)) order by dateTime";
+  $stmt = mysqli_prepare($link, $sql);
+  mysqli_stmt_bind_param($stmt, 'ss', $startDay, $endDay);
 } else {
   $sql = "select dateTime * 1000 as datetime, round(MIN($itemmm),1) as datamin, round(MAX($itemmm),1) as datamax from $table where dateTime BETWEEN UNIX_TIMESTAMP(?) AND UNIX_TIMESTAMP(?)  GROUP BY hour(FROM_UNIXTIME(dateTime)),day(FROM_UNIXTIME(dateTime)) order by dateTime";
+  $stmt = mysqli_prepare($link, $sql);
+  mysqli_stmt_bind_param($stmt, 'ss', $startTime, $endTime);
 }
-$stmt = mysqli_prepare($link, $sql);
-mysqli_stmt_bind_param($stmt, 'ss', $startTime, $endTime);
 mysqli_stmt_execute($stmt);
 $result = mysqli_stmt_get_result($stmt);
 


### PR DESCRIPTION
## Summary
- Round rainfall queries to full-day boundaries so totals aren't partial when zooming

## Testing
- `php -l frontend/backend/range-data.php`
- `php -l frontend/historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc1abdff7c832eb90644492ac4cb96