### PR TITLE
Enrich metric cards with vibrant palettes

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -218,32 +218,45 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
     .metric-card {
       position: relative;
       display: block;
-      border-radius: 1.5rem;
-      padding: 1.5rem;
-      background: linear-gradient(145deg, rgba(var(--accent), 0.18), rgba(255, 255, 255, 0.92));
-      border: 1px solid rgba(var(--accent), 0.35);
-      box-shadow: 0 35px 70px -48px rgba(var(--accent), 0.48);
-      backdrop-filter: blur(20px);
-      overflow: hidden;
-      transition: transform 0.35s ease, box-shadow 0.35s ease, background 0.35s ease;
+      border-radius: 1.65rem;
+      padding: 1.75rem;
       --accent: 59 130 246;
-      cursor: pointer;
-      color: inherit;
+      --accent-strong: 37 99 235;
+      --accent-soft: 125 211 252;
+      --accent-glow: 224 242 254;
+      color: #0f172a;
       text-decoration: none;
+      cursor: pointer;
+      isolation: isolate;
+      overflow: hidden;
+      background:
+        radial-gradient(circle at -10% -10%, rgba(var(--accent-strong), 0.94) 0%, rgba(var(--accent-strong), 0.15) 45%, transparent 65%),
+        radial-gradient(circle at 85% -15%, rgba(var(--accent), 0.75) 0%, rgba(var(--accent), 0.12) 55%, transparent 75%),
+        linear-gradient(135deg,
+          rgba(var(--accent-strong), 0.9) 0%,
+          rgba(var(--accent), 0.7) 42%,
+          rgba(var(--accent-glow), 0.95) 100%);
+      border: 1px solid rgba(var(--accent-strong), 0.42);
+      box-shadow:
+        0 26px 65px -30px rgba(var(--accent-strong), 0.75),
+        0 14px 38px -20px rgba(var(--accent-soft), 0.6);
+      transition: transform 0.35s ease, box-shadow 0.35s ease, filter 0.35s ease;
     }
     .metric-card:focus-visible {
-      outline: 3px solid rgba(56, 189, 248, 0.65);
+      outline: 3px solid rgba(var(--accent-soft), 0.85);
       outline-offset: 4px;
     }
-    html.dark .metric-card:focus-visible { outline-color: rgba(125, 211, 252, 0.8); }
+    html.dark .metric-card:focus-visible { outline-color: rgba(var(--accent-glow), 0.85); }
     .metric-card::before {
       content: "";
       position: absolute;
-      inset: 0;
+      inset: -35% -15% 35% -25%;
       background:
-        radial-gradient(circle at 20% 15%, rgba(var(--accent), 0.32), transparent 55%),
-        radial-gradient(circle at 85% 110%, rgba(var(--accent), 0.18), transparent 65%);
-      opacity: 0.85;
+        conic-gradient(from 120deg at 32% 28%, rgba(var(--accent-soft), 0.75) 0%, rgba(var(--accent), 0.15) 48%, transparent 72%),
+        radial-gradient(circle at 80% 20%, rgba(var(--accent-glow), 0.85), transparent 58%),
+        radial-gradient(circle at 15% 95%, rgba(var(--accent), 0.35), transparent 65%);
+      mix-blend-mode: screen;
+      opacity: 0.95;
       pointer-events: none;
       transition: opacity 0.35s ease, transform 0.35s ease;
     }
@@ -251,35 +264,46 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
       content: "";
       position: absolute;
       inset: 1px;
-      border-radius: 1.45rem;
-      border: 1px solid rgba(255, 255, 255, 0.5);
+      border-radius: 1.6rem;
+      border: 1px solid rgba(255, 255, 255, 0.55);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
       mix-blend-mode: soft-light;
       pointer-events: none;
-      opacity: 0.8;
+      opacity: 0.9;
     }
     .metric-card:hover {
-      transform: translateY(-6px);
-      background: linear-gradient(145deg, rgba(var(--accent), 0.24), rgba(255, 255, 255, 0.98));
-      box-shadow: 0 48px 100px -52px rgba(var(--accent), 0.55);
+      transform: translateY(-10px);
+      box-shadow:
+        0 36px 95px -34px rgba(var(--accent-strong), 0.8),
+        0 18px 48px -24px rgba(var(--accent-soft), 0.7);
+      filter: brightness(1.02) saturate(1.05);
     }
     .metric-card:hover::before {
       opacity: 1;
-      transform: translateY(-2px);
+      transform: translate3d(0, -6px, 0) scale(1.04);
     }
     html.dark .metric-card {
-      background: linear-gradient(145deg, rgba(var(--accent), 0.33), rgba(15, 23, 42, 0.88));
-      border-color: rgba(var(--accent), 0.45);
-      box-shadow: 0 35px 65px -45px rgba(var(--accent), 0.65);
+      color: #f8fafc;
+      background:
+        radial-gradient(circle at -10% -20%, rgba(var(--accent-strong), 0.88) 0%, rgba(var(--accent-strong), 0.2) 45%, transparent 68%),
+        radial-gradient(circle at 95% -15%, rgba(var(--accent-soft), 0.65) 0%, rgba(var(--accent-soft), 0.18) 55%, transparent 75%),
+        linear-gradient(150deg,
+          rgba(var(--accent-strong), 0.82) 0%,
+          rgba(var(--accent), 0.62) 45%,
+          rgba(2, 6, 23, 0.95) 100%);
+      border-color: rgba(var(--accent-soft), 0.5);
+      box-shadow:
+        0 28px 70px -32px rgba(var(--accent-strong), 0.85),
+        0 14px 42px -22px rgba(15, 23, 42, 0.6);
     }
     html.dark .metric-card::before {
-      background:
-        radial-gradient(circle at 20% 15%, rgba(var(--accent), 0.38), transparent 55%),
-        radial-gradient(circle at 85% 110%, rgba(var(--accent), 0.28), transparent 65%);
+      mix-blend-mode: lighten;
+      opacity: 0.75;
     }
     html.dark .metric-card::after {
-      border-color: rgba(226, 232, 240, 0.3);
+      border-color: rgba(226, 232, 240, 0.35);
+      box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.18);
       mix-blend-mode: screen;
-      opacity: 0.9;
     }
     .metric-card .metric-label {
       display: inline-block;
@@ -287,32 +311,41 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
       letter-spacing: 0.18em;
       text-transform: uppercase;
       font-weight: 600;
-      color: rgba(var(--accent), 0.95);
+      color: rgba(var(--accent-strong), 0.95);
       margin-bottom: 0.75rem;
-      text-shadow: 0 6px 18px rgba(var(--accent), 0.35);
+      text-shadow: 0 12px 26px rgba(var(--accent-strong), 0.55);
+    }
+    html.dark .metric-card .metric-label {
+      color: rgba(var(--accent-glow), 0.95);
+      text-shadow: 0 12px 28px rgba(var(--accent-soft), 0.6);
     }
     .metric-card .metric-value {
-      font-size: 1.875rem;
+      font-size: 1.95rem;
       font-weight: 700;
-      color: rgba(15, 23, 42, 0.92);
-      text-shadow: 0 14px 30px rgba(var(--accent), 0.25);
+      color: rgba(15, 23, 42, 0.95);
+      text-shadow: 0 16px 32px rgba(var(--accent-strong), 0.25);
     }
     html.dark .metric-card .metric-value {
-      color: #f8fafc;
-      text-shadow: 0 18px 32px rgba(var(--accent), 0.4);
+      color: rgba(226, 232, 240, 0.98);
+      text-shadow: 0 18px 38px rgba(var(--accent-soft), 0.65);
     }
     .metric-card .metric-meta {
-      margin-top: 0.25rem;
+      margin-top: 0.35rem;
       font-size: 0.78rem;
-      color: rgba(var(--accent), 0.65);
+      font-weight: 500;
+      color: rgba(var(--accent-strong), 0.78);
     }
-    html.dark .metric-card .metric-meta { color: rgba(var(--accent), 0.75); }
+    html.dark .metric-card .metric-meta {
+      color: rgba(var(--accent-soft), 0.85);
+    }
     .metric-card i {
-      color: rgba(var(--accent), 0.72);
-      text-shadow: 0 16px 28px rgba(var(--accent), 0.4);
+      color: rgba(255, 255, 255, 0.92);
+      text-shadow:
+        0 20px 35px rgba(var(--accent-strong), 0.48),
+        0 8px 18px rgba(var(--accent-soft), 0.35);
     }
     html.dark .metric-card i {
-      color: rgba(var(--accent), 0.65);
+      color: rgba(var(--accent-glow), 0.9);
     }
     .glass-panel {
       background: linear-gradient(135deg, rgba(255, 255, 255, 0.75), rgba(241, 245, 249, 0.55));

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -18,7 +18,7 @@ require_once '../dbconn.php';
   </div>
 
   <div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-    <a href="dynamic-graph.php?WHAT=outTemp&SCALE=day" class="metric-card" style="--accent: 239 68 68;">
+    <a href="dynamic-graph.php?WHAT=outTemp&SCALE=day" class="metric-card" style="--accent: 239 68 68; --accent-strong: 220 38 38; --accent-soft: 252 165 165; --accent-glow: 254 226 226;">
       <div class="flex items-start justify-between gap-3">
         <div>
           <span class="metric-label">Outside Temperature</span>
@@ -31,7 +31,7 @@ require_once '../dbconn.php';
       </div>
     </a>
 
-    <a href="dynamic-graph.php?WHAT=outHumidity&SCALE=day" class="metric-card" style="--accent: 16 185 129;">
+    <a href="dynamic-graph.php?WHAT=outHumidity&SCALE=day" class="metric-card" style="--accent: 16 185 129; --accent-strong: 5 150 105; --accent-soft: 110 231 183; --accent-glow: 167 243 208;">
       <div class="flex items-start justify-between gap-3">
         <div>
           <span class="metric-label">Outside Humidity</span>
@@ -44,7 +44,7 @@ require_once '../dbconn.php';
       </div>
     </a>
 
-    <a href="dynamic-graph.php?WHAT=windSpeed&SCALE=day" class="metric-card" style="--accent: 14 165 233;">
+    <a href="dynamic-graph.php?WHAT=windSpeed&SCALE=day" class="metric-card" style="--accent: 14 165 233; --accent-strong: 2 132 199; --accent-soft: 125 211 252; --accent-glow: 191 233 255;">
       <div class="flex items-start justify-between gap-3">
         <div>
           <span class="metric-label">Wind Speed</span>
@@ -57,7 +57,7 @@ require_once '../dbconn.php';
       </div>
     </a>
 
-    <a href="dynamic-graph.php?WHAT=barometer&SCALE=day" class="metric-card" style="--accent: 234 179 8;">
+    <a href="dynamic-graph.php?WHAT=barometer&SCALE=day" class="metric-card" style="--accent: 234 179 8; --accent-strong: 202 138 4; --accent-soft: 253 224 71; --accent-glow: 254 243 199;">
       <div class="flex items-start justify-between gap-3">
         <div>
           <span class="metric-label">Barometer</span>
@@ -70,7 +70,7 @@ require_once '../dbconn.php';
       </div>
     </a>
 
-    <a href="dynamic-graph.php?WHAT=dewpoint&SCALE=day" class="metric-card" style="--accent: 168 85 247;">
+    <a href="dynamic-graph.php?WHAT=dewpoint&SCALE=day" class="metric-card" style="--accent: 168 85 247; --accent-strong: 126 34 206; --accent-soft: 196 181 253; --accent-glow: 221 214 254;">
       <div class="flex items-start justify-between gap-3">
         <div>
           <span class="metric-label">Dew Point</span>
@@ -83,7 +83,7 @@ require_once '../dbconn.php';
       </div>
     </a>
 
-    <a href="dynamic-graph.php?WHAT=windchill&SCALE=day" class="metric-card" style="--accent: 129 140 248;">
+    <a href="dynamic-graph.php?WHAT=windchill&SCALE=day" class="metric-card" style="--accent: 129 140 248; --accent-strong: 99 102 241; --accent-soft: 165 180 252; --accent-glow: 199 210 254;">
       <div class="flex items-start justify-between gap-3">
         <div>
           <span class="metric-label">Wind Chill</span>
@@ -96,7 +96,7 @@ require_once '../dbconn.php';
       </div>
     </a>
 
-    <a href="dynamic-graph.php?WHAT=rain&SCALE=day" class="metric-card" style="--accent: 59 130 246;">
+    <a href="dynamic-graph.php?WHAT=rain&SCALE=day" class="metric-card" style="--accent: 59 130 246; --accent-strong: 37 99 235; --accent-soft: 96 165 250; --accent-glow: 191 219 254;">
       <div class="flex items-start justify-between gap-3">
         <div>
           <span class="metric-label">Rain Today</span>
@@ -109,7 +109,7 @@ require_once '../dbconn.php';
       </div>
     </a>
 
-    <a href="dynamic-graph.php?WHAT=rain&TYPE=MINMAX&SCALE=month" class="metric-card" style="--accent: 37 99 235;">
+    <a href="dynamic-graph.php?WHAT=rain&TYPE=MINMAX&SCALE=month" class="metric-card" style="--accent: 249 115 22; --accent-strong: 217 119 6; --accent-soft: 253 186 116; --accent-glow: 254 215 170;">
       <div class="flex items-start justify-between gap-3">
         <div>
           <span class="metric-label">Rain this Month</span>
@@ -122,7 +122,7 @@ require_once '../dbconn.php';
       </div>
     </a>
 
-    <a href="dynamic-graph.php?WHAT=windGust&SCALE=day" class="metric-card" style="--accent: 14 165 233;">
+    <a href="dynamic-graph.php?WHAT=windGust&SCALE=day" class="metric-card" style="--accent: 56 189 248; --accent-strong: 14 165 233; --accent-soft: 125 211 252; --accent-glow: 224 242 254;">
       <div class="flex items-start justify-between gap-3">
         <div>
           <span class="metric-label">Wind Gust</span>
@@ -138,7 +138,7 @@ require_once '../dbconn.php';
       </div>
     </a>
 
-    <a href="dynamic-graph.php?WHAT=windDir&SCALE=day" class="metric-card" style="--accent: 56 189 248;">
+    <a href="dynamic-graph.php?WHAT=windDir&SCALE=day" class="metric-card" style="--accent: 45 212 191; --accent-strong: 13 148 136; --accent-soft: 94 234 212; --accent-glow: 204 251 241;">
       <div class="flex items-start justify-between gap-3">
         <div>
           <span class="metric-label">Wind Direction</span>


### PR DESCRIPTION
## Summary
- overhaul the metric card styling with multi-accent gradients, glow layers, and refined typography for brighter light/dark themes
- assign per-sensor accent palettes so each dashboard tile carries its own saturated color story

## Testing
- php -l frontend/header.php
- php -l frontend/index.php

------
https://chatgpt.com/codex/tasks/task_e_68caeb260d5c832eaecb9da3ea39548d