### PR TITLE
style: add gradient to Current Conditions hero card

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -212,6 +212,64 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
       border-color: var(--surface-border-dark);
       box-shadow: 0 35px 80px -45px rgba(30, 64, 175, 0.45);
     }
+    .current-conditions-card {
+      position: relative;
+      overflow: hidden;
+      border-radius: 1.85rem;
+      padding: 2.25rem 2.5rem;
+      background: linear-gradient(120deg, rgba(59, 130, 246, 0.95), rgba(129, 140, 248, 0.9));
+      box-shadow:
+        0 28px 60px -38px rgba(30, 64, 175, 0.6),
+        0 12px 32px -20px rgba(99, 102, 241, 0.45);
+      border: 1px solid rgba(255, 255, 255, 0.28);
+      color: #f8fafc;
+    }
+    .current-conditions-card::before {
+      content: "";
+      position: absolute;
+      inset: -25% 40% 20% -15%;
+      background: radial-gradient(circle at top, rgba(255, 255, 255, 0.35), transparent 65%);
+      filter: blur(0.5px);
+      opacity: 0.75;
+      pointer-events: none;
+    }
+    .current-conditions-card h1 {
+      color: #f8fafc;
+    }
+    .current-conditions-card p {
+      color: rgba(248, 250, 252, 0.85);
+    }
+    .current-conditions-card .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.9rem 1.75rem;
+      border-radius: 9999px;
+      background: rgba(15, 23, 42, 0.25);
+      border: 1px solid rgba(255, 255, 255, 0.3);
+      color: rgba(248, 250, 252, 0.8);
+      font-size: 0.75rem;
+      letter-spacing: 0.35em;
+      text-transform: uppercase;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15);
+      backdrop-filter: blur(18px);
+    }
+    .current-conditions-card .status-pill i {
+      font-size: 1.1rem;
+      color: rgba(191, 219, 254, 0.95);
+    }
+    html.dark .current-conditions-card {
+      background: linear-gradient(120deg, rgba(30, 64, 175, 0.88), rgba(76, 29, 149, 0.85));
+      border-color: rgba(148, 163, 184, 0.35);
+      box-shadow:
+        0 28px 60px -38px rgba(30, 64, 175, 0.7),
+        0 18px 38px -24px rgba(76, 29, 149, 0.45);
+    }
+    html.dark .current-conditions-card .status-pill {
+      background: rgba(15, 23, 42, 0.45);
+      border-color: rgba(148, 163, 184, 0.35);
+      color: rgba(226, 232, 240, 0.85);
+    }
     @media (max-width: 768px) {
       .content-wrapper { padding: 2rem 1.5rem; border-radius: 1.5rem; }
     }

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -6,14 +6,16 @@ require_once '../dbconn.php';
 <script src="https://cdnjs.cloudflare.com/ajax/libs/paho-mqtt/1.0.1/mqttws31.js" type="text/javascript"></script>
 
 <div class="space-y-10">
-  <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
-    <div>
-      <h1 class="text-4xl font-bold text-slate-900 dark:text-slate-100 drop-shadow-sm">Current Conditions</h1>
-      <p class="mt-3 text-sm text-slate-600 dark:text-slate-300 max-w-2xl">Live insights from the Wheathampstead personal weather station, refreshed in near real-time for rapid decision making.</p>
-    </div>
-    <div class="flex items-center gap-3 text-xs sm:text-sm text-slate-500 dark:text-slate-300 bg-white/60 dark:bg-slate-900/60 border border-white/40 dark:border-slate-700/60 rounded-full px-5 py-3 shadow-inner backdrop-blur">
-      <i class="fas fa-broadcast-tower text-sky-500"></i>
-      <span class="uppercase tracking-[0.35em]">Tap a card to explore the trend</span>
+  <div class="current-conditions-card">
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+      <div>
+        <h1 class="text-4xl font-bold drop-shadow-sm">Current Conditions</h1>
+        <p class="mt-3 text-sm max-w-2xl">Live insights from the Wheathampstead personal weather station, refreshed in near real-time for rapid decision making.</p>
+      </div>
+      <div class="status-pill">
+        <i class="fas fa-broadcast-tower"></i>
+        <span class="uppercase tracking-[0.35em]">Tap a card to explore the trend</span>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- wrap the Current Conditions intro in a dedicated card container
- apply a two-color gradient treatment and supporting styles for the hero card
- refresh the status pill styling so the text remains legible on the gradient background

## Testing
- php -l frontend/index.php
- php -l frontend/header.php

------
https://chatgpt.com/codex/tasks/task_e_68caeec0f558832e8f7975d86ed8f044