### PR TITLE
style: refine hero gradient and sensor cards

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -212,6 +212,64 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
       border-color: var(--surface-border-dark);
       box-shadow: 0 35px 80px -45px rgba(30, 64, 175, 0.45);
     }
+    .current-conditions-card {
+      position: relative;
+      overflow: hidden;
+      border-radius: 1.85rem;
+      padding: 2.25rem 2.5rem;
+      background: linear-gradient(120deg, rgba(59, 130, 246, 0.95), rgba(129, 140, 248, 0.9));
+      box-shadow:
+        0 28px 60px -38px rgba(30, 64, 175, 0.6),
+        0 12px 32px -20px rgba(99, 102, 241, 0.45);
+      border: 1px solid rgba(255, 255, 255, 0.28);
+      color: #f8fafc;
+    }
+    .current-conditions-card::before {
+      content: "";
+      position: absolute;
+      inset: -25% 40% 20% -15%;
+      background: radial-gradient(circle at top, rgba(255, 255, 255, 0.35), transparent 65%);
+      filter: blur(0.5px);
+      opacity: 0.75;
+      pointer-events: none;
+    }
+    .current-conditions-card h1 {
+      color: #f8fafc;
+    }
+    .current-conditions-card p {
+      color: rgba(248, 250, 252, 0.85);
+    }
+    .current-conditions-card .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.9rem 1.75rem;
+      border-radius: 9999px;
+      background: rgba(15, 23, 42, 0.25);
+      border: 1px solid rgba(255, 255, 255, 0.3);
+      color: rgba(248, 250, 252, 0.8);
+      font-size: 0.75rem;
+      letter-spacing: 0.35em;
+      text-transform: uppercase;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15);
+      backdrop-filter: blur(18px);
+    }
+    .current-conditions-card .status-pill i {
+      font-size: 1.1rem;
+      color: rgba(191, 219, 254, 0.95);
+    }
+    html.dark .current-conditions-card {
+      background: linear-gradient(120deg, rgba(30, 64, 175, 0.88), rgba(76, 29, 149, 0.85));
+      border-color: rgba(148, 163, 184, 0.35);
+      box-shadow:
+        0 28px 60px -38px rgba(30, 64, 175, 0.7),
+        0 18px 38px -24px rgba(76, 29, 149, 0.45);
+    }
+    html.dark .current-conditions-card .status-pill {
+      background: rgba(15, 23, 42, 0.45);
+      border-color: rgba(148, 163, 184, 0.35);
+      color: rgba(226, 232, 240, 0.85);
+    }
     @media (max-width: 768px) {
       .content-wrapper { padding: 2rem 1.5rem; border-radius: 1.5rem; }
     }
@@ -232,17 +290,16 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
       isolation: isolate;
       overflow: hidden;
       background:
-        radial-gradient(circle at -10% -10%, rgba(var(--accent-strong), 0.94) 0%, rgba(var(--accent-strong), 0.15) 45%, transparent 65%),
-        radial-gradient(circle at 85% -15%, rgba(var(--accent), 0.75) 0%, rgba(var(--accent), 0.12) 55%, transparent 75%),
-        linear-gradient(135deg,
-          rgba(var(--accent-strong), 0.9) 0%,
-          rgba(var(--accent), 0.7) 42%,
-          rgba(var(--accent-glow), 0.95) 100%);
-      border: 1px solid rgba(var(--accent-strong), 0.42);
+        linear-gradient(160deg,
+          rgba(var(--accent-strong), 0.28) 0%,
+          rgba(var(--accent), 0.18) 42%,
+          rgba(255, 255, 255, 0.48) 100%);
+      border: 1px solid rgba(var(--accent-strong), 0.28);
       box-shadow:
-        0 26px 65px -30px rgba(var(--accent-strong), 0.75),
-        0 14px 38px -20px rgba(var(--accent-soft), 0.6);
-      transition: transform 0.35s ease, box-shadow 0.35s ease, filter 0.35s ease;
+        0 26px 55px -34px rgba(var(--accent-strong), 0.55),
+        0 14px 32px -24px rgba(var(--accent-soft), 0.45);
+      backdrop-filter: blur(18px);
+      transition: transform 0.35s ease, box-shadow 0.35s ease, filter 0.35s ease, background 0.35s ease;
     }
     .metric-card:focus-visible {
       outline: 3px solid rgba(var(--accent-soft), 0.85);
@@ -252,15 +309,12 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
     .metric-card::before {
       content: "";
       position: absolute;
-      inset: -35% -15% 35% -25%;
+      inset: -28% -12% 32% -20%;
       background:
-
-        conic-gradient(from 120deg at 32% 28%, rgba(var(--accent-soft), 0.75) 0%, rgba(var(--accent), 0.15) 48%, transparent 72%),
-        radial-gradient(circle at 80% 20%, rgba(var(--accent-glow), 0.85), transparent 58%),
-        radial-gradient(circle at 15% 95%, rgba(var(--accent), 0.35), transparent 65%);
+        radial-gradient(circle at 18% 22%, rgba(var(--accent-soft), 0.4), transparent 58%),
+        radial-gradient(circle at 80% 18%, rgba(var(--accent), 0.22), transparent 70%);
       mix-blend-mode: screen;
-
-      opacity: 0.95;
+      opacity: 0.65;
       pointer-events: none;
       transition: opacity 0.35s ease, transform 0.35s ease;
     }
@@ -268,50 +322,46 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
       content: "";
       position: absolute;
       inset: 1px;
-
       border-radius: 1.6rem;
-
-      border: 1px solid rgba(255, 255, 255, 0.55);
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+      border: 1px solid rgba(255, 255, 255, 0.45);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
       mix-blend-mode: soft-light;
       pointer-events: none;
-
-      opacity: 0.9;
+      opacity: 0.75;
     }
     .metric-card:hover {
       transform: translateY(-10px);
       box-shadow:
-        0 36px 95px -34px rgba(var(--accent-strong), 0.8),
-        0 18px 48px -24px rgba(var(--accent-soft), 0.7);
-      filter: brightness(1.02) saturate(1.05);
+        0 32px 85px -34px rgba(var(--accent-strong), 0.65),
+        0 18px 42px -24px rgba(var(--accent-soft), 0.55);
+      filter: brightness(1.04) saturate(1.06);
     }
     .metric-card:hover::before {
-      opacity: 1;
+      opacity: 0.8;
       transform: translate3d(0, -6px, 0) scale(1.04);
     }
     html.dark .metric-card {
       color: #f8fafc;
       background:
-        radial-gradient(circle at -10% -20%, rgba(var(--accent-strong), 0.88) 0%, rgba(var(--accent-strong), 0.2) 45%, transparent 68%),
-        radial-gradient(circle at 95% -15%, rgba(var(--accent-soft), 0.65) 0%, rgba(var(--accent-soft), 0.18) 55%, transparent 75%),
-        linear-gradient(150deg,
-          rgba(var(--accent-strong), 0.82) 0%,
-          rgba(var(--accent), 0.62) 45%,
-          rgba(2, 6, 23, 0.95) 100%);
-      border-color: rgba(var(--accent-soft), 0.5);
+        linear-gradient(160deg,
+          rgba(var(--accent-strong), 0.32) 0%,
+          rgba(var(--accent-soft), 0.2) 45%,
+          rgba(2, 6, 23, 0.7) 100%);
+      border-color: rgba(var(--accent-soft), 0.4);
       box-shadow:
-        0 28px 70px -32px rgba(var(--accent-strong), 0.85),
-        0 14px 42px -22px rgba(15, 23, 42, 0.6);
+        0 28px 70px -32px rgba(var(--accent-strong), 0.65),
+        0 14px 42px -22px rgba(2, 6, 23, 0.7);
+      backdrop-filter: blur(20px);
     }
     html.dark .metric-card::before {
       mix-blend-mode: lighten;
-      opacity: 0.75;
+      opacity: 0.6;
     }
     html.dark .metric-card::after {
-      border-color: rgba(226, 232, 240, 0.35);
-      box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.18);
+      border-color: rgba(226, 232, 240, 0.28);
+      box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.15);
       mix-blend-mode: screen;
-
+      opacity: 0.65;
     }
     .metric-card .metric-label {
       display: inline-block;
@@ -320,13 +370,13 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
       text-transform: uppercase;
       font-weight: 600;
 
-      color: rgba(var(--accent-strong), 0.95);
+      color: rgba(59, 130, 246, 0.92);
       margin-bottom: 0.75rem;
-      text-shadow: 0 12px 26px rgba(var(--accent-strong), 0.55);
+      text-shadow: 0 12px 26px rgba(59, 130, 246, 0.35);
     }
     html.dark .metric-card .metric-label {
-      color: rgba(var(--accent-glow), 0.95);
-      text-shadow: 0 12px 28px rgba(var(--accent-soft), 0.6);
+      color: rgba(191, 219, 254, 0.95);
+      text-shadow: 0 12px 26px rgba(148, 197, 255, 0.45);
 
     }
     .metric-card .metric-value {

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -6,13 +6,13 @@ require_once '../dbconn.php';
 <script src="https://cdnjs.cloudflare.com/ajax/libs/paho-mqtt/1.0.1/mqttws31.js" type="text/javascript"></script>
 
 <div class="space-y-10">
-  <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+  <div class="current-conditions-card flex flex-col md:flex-row md:items-center md:justify-between gap-6">
     <div>
-      <h1 class="text-4xl font-bold text-slate-900 dark:text-slate-100 drop-shadow-sm">Current Conditions</h1>
-      <p class="mt-3 text-sm text-slate-600 dark:text-slate-300 max-w-2xl">Live insights from the Wheathampstead personal weather station, refreshed in near real-time for rapid decision making.</p>
+      <h1 class="text-4xl font-bold drop-shadow-sm">Current Conditions</h1>
+      <p class="mt-3 text-sm max-w-2xl">Live insights from the Wheathampstead personal weather station, refreshed in near real-time for rapid decision making.</p>
     </div>
-    <div class="flex items-center gap-3 text-xs sm:text-sm text-slate-500 dark:text-slate-300 bg-white/60 dark:bg-slate-900/60 border border-white/40 dark:border-slate-700/60 rounded-full px-5 py-3 shadow-inner backdrop-blur">
-      <i class="fas fa-broadcast-tower text-sky-500"></i>
+    <div class="status-pill">
+      <i class="fas fa-broadcast-tower"></i>
       <span class="uppercase tracking-[0.35em]">Tap a card to explore the trend</span>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- maintain the gradient styling for the Current Conditions hero without adding an extra wrapper
- soften the sensor metric cards with translucent treatments and blue headings that tie into the hero gradient
- keep the status pill updates so the call-to-action remains legible on the gradient background

## Testing
- php -l frontend/index.php
- php -l frontend/header.php

------
https://chatgpt.com/codex/tasks/task_e_68caeec0f558832e8f7975d86ed8f044