### PR TITLE
Adjust hero quick stats and sensor styling

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -757,7 +757,10 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
     .metric-card .metric-meta {
       font-size: 0.8rem;
       font-weight: 500;
-      color: rgba(226, 232, 240, 0.85);
+      color: #6b7280;
+    }
+    html.dark .metric-card .metric-meta {
+      color: #6b7280;
     }
     .metric-card i {
       font-size: 1.75rem;
@@ -910,6 +913,30 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
       color: rgba(15, 23, 42, 0.6);
     }
     html.dark .hero-stat .stat-meta { color: rgba(226, 232, 240, 0.7); }
+    .hero-stats-grid .insight-card {
+      height: 100%;
+    }
+    .stat-reading {
+      display: inline-flex;
+      align-items: baseline;
+      gap: 0.35rem;
+      font-weight: 600;
+    }
+    .stat-unit {
+      color: #6b7280;
+      font-size: 0.85rem;
+      font-weight: 500;
+    }
+    .stat-value [data-stat],
+    .metric-value [data-stat],
+    .insight-list [data-stat],
+    .stat-reading [data-stat] {
+      color: #000;
+    }
+    .metric-meta,
+    .stat-meta {
+      color: #6b7280;
+    }
     .section-header {
       display: flex;
       flex-wrap: wrap;
@@ -981,16 +1008,28 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
       justify-content: space-between;
       align-items: baseline;
       font-size: 0.95rem;
-      color: rgba(15, 23, 42, 0.75);
+      color: #6b7280;
     }
-    html.dark .insight-list li { color: rgba(226, 232, 240, 0.78); }
+    html.dark .insight-list li { color: #6b7280; }
     .insight-list .label {
       text-transform: uppercase;
       letter-spacing: 0.18em;
       font-size: 0.72rem;
-      color: rgba(15, 23, 42, 0.6);
+      color: #6b7280;
+      font-weight: 600;
     }
-    html.dark .insight-list .label { color: rgba(148, 163, 184, 0.7); }
+    html.dark .insight-list .label { color: #6b7280; }
+    .insight-list .stat-unit {
+      color: #6b7280;
+    }
+    html.dark .insight-list .stat-unit { color: #6b7280; }
+    html.dark .metric-meta,
+    html.dark .stat-meta {
+      color: #6b7280;
+    }
+    html.dark .stat-unit {
+      color: #6b7280;
+    }
     .glass-panel {
       background: linear-gradient(150deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.06));
       border-radius: 2rem;
@@ -1089,12 +1128,9 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
   </button>
     <div class="flex min-h-screen">
 
-      <aside id="sidebar" class="text-gray-900 dark:text-gray-100 w-64 space-y-4 py-6 px-4 absolute inset-y-0 left-0 z-40 transform -translate-x-full md:relative md:translate-x-0 transition-transform duration-300 ease-in-out rounded-3xl overflow-y-auto md:overflow-visible max-h-screen md:max-h-none">
+      <aside id="sidebar" class="text-gray-900 dark:text-gray-100 w-[18.4rem] space-y-4 py-6 px-4 absolute inset-y-0 left-0 z-40 transform -translate-x-full md:relative md:translate-x-0 transition-transform duration-300 ease-in-out rounded-3xl overflow-y-auto md:overflow-visible max-h-screen md:max-h-none">
 
       <a id="navname" class="px-4 text-lg font-semibold" href="/">
-        <span class="brand-icon">
-          <img src="/images/icon.png" class="w-8 h-8" alt="Site icon">
-        </span>
         <span class="brand-copy">
           <span class="brand-title">Wheathampstead Weather</span>
           <span class="brand-subtitle">Local conditions in real time</span>

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -22,37 +22,36 @@ require_once '../dbconn.php';
         </div>
       </div>
       <div class="hero-stats-grid">
-        <div class="hero-stat">
-          <span class="stat-label">Outside Temperature</span>
-          <span class="stat-value">
-            <span data-stat="OutTemp">--</span>
-            <span class="stat-unit">°C</span>
-          </span>
-          <span class="stat-meta">Feels like <span data-stat="Windchill">--</span>°C</span>
-        </div>
-        <div class="hero-stat">
-          <span class="stat-label">Humidity</span>
-          <span class="stat-value">
-            <span data-stat="OutHumidity">--</span>
-            <span class="stat-unit">%</span>
-          </span>
-          <span class="stat-meta">Dew point <span data-stat="Dewpoint">--</span>°C</span>
-        </div>
-        <div class="hero-stat">
-          <span class="stat-label">Wind Speed</span>
-          <span class="stat-value">
-            <span data-stat="windSpeed_kph">--</span>
-            <span class="stat-unit">kph</span>
-          </span>
-          <span class="stat-meta">Gust <span data-stat="windGust_kph">--</span> kph · Dir <span data-stat="windDir">--</span>°</span>
-        </div>
-        <div class="hero-stat">
-          <span class="stat-label">Barometer</span>
-          <span class="stat-value">
-            <span data-stat="Barometer">--</span>
-            <span class="stat-unit">mbar</span>
-          </span>
-          <span class="stat-meta">Daily rain <span data-stat="drain">--</span> cm</span>
+        <div class="insight-card hero-quick-stats">
+          <div class="flex items-baseline justify-between">
+            <span class="text-xs uppercase tracking-[0.3em] text-slate-600 dark:text-slate-300">Quick Stats</span>
+            <i class="fas fa-layer-group text-slate-400 dark:text-slate-500"></i>
+          </div>
+          <ul class="insight-list">
+            <li>
+              <span class="label">Rain Today</span>
+              <span class="stat-reading">
+                <span data-stat="drain">--</span>
+                <span class="stat-unit">cm</span>
+              </span>
+            </li>
+            <li>
+              <span class="label">Rain This Month</span>
+              <span class="stat-reading">
+                <span data-stat="mrain">--</span>
+                <span class="stat-unit">cm</span>
+              </span>
+            </li>
+            <li>
+              <span class="label">Peak Gust</span>
+              <span class="stat-reading">
+                <span data-stat="windGust_kph">--</span>
+                <span class="stat-unit">kph · Dir</span>
+                <span data-stat="windGustDir">--</span>
+                <span class="stat-unit">°</span>
+              </span>
+            </li>
+          </ul>
         </div>
       </div>
     </div>
@@ -224,17 +223,6 @@ require_once '../dbconn.php';
           <p class="text-sm text-slate-600 dark:text-slate-300 leading-relaxed">Pair the data stream with the immediate view outside the station.</p>
           <img src="https://www.smeird.com/images/snap.jpeg" class="w-full h-auto rounded-2xl border border-white/40 dark:border-slate-700/60 shadow-lg shadow-slate-900/20 dark:shadow-slate-900/60" alt="Station garden snapshot">
         </div>
-      </div>
-      <div class="insight-card">
-        <div class="flex items-baseline justify-between">
-          <span class="text-xs uppercase tracking-[0.3em] text-slate-600 dark:text-slate-300">Quick Stats</span>
-          <i class="fas fa-layer-group text-slate-400 dark:text-slate-500"></i>
-        </div>
-        <ul class="insight-list">
-          <li><span class="label">Rain Today</span><span><span data-stat="drain">--</span> cm</span></li>
-          <li><span class="label">Rain This Month</span><span><span data-stat="mrain">--</span> cm</span></li>
-          <li><span class="label">Peak Gust</span><span><span data-stat="windGust_kph">--</span> kph · <span data-stat="windGustDir">--</span>°</span></li>
-        </ul>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- replace the hero stat tiles with the quick stats panel and remove the duplicate from the lower column
- make sensor readings use black numbers with grey supporting text across hero and metric cards
- widen the sidebar by 15% and drop the favicon graphic from the navigation header

## Testing
- php -l frontend/header.php
- php -l frontend/index.php

------
https://chatgpt.com/codex/tasks/task_e_68cbb763b730832e98f7251ac6e0631f