### PR TITLE
Add quick stats temperature extremes and hero styling adjustments

### DIFF
--- a/frontend/backend/today-extremes.php
+++ b/frontend/backend/today-extremes.php
@@ -1,0 +1,47 @@
+<?php
+require_once '../../dbconn.php';
+
+date_default_timezone_set('Europe/London');
+
+$timezone = new DateTimeZone('Europe/London');
+$start = new DateTimeImmutable('today', $timezone);
+$end = $start->modify('+1 day');
+
+$startTimestamp = $start->getTimestamp();
+$endTimestamp = $end->getTimestamp();
+
+$sql = 'SELECT MAX(outTemp) AS high, MIN(outTemp) AS low FROM archive WHERE dateTime >= ? AND dateTime < ?';
+$stmt = mysqli_prepare($link, $sql);
+if (! $stmt) {
+  http_response_code(500);
+  header('Content-Type: application/json');
+  echo json_encode(['error' => 'Unable to prepare statement']);
+  exit;
+}
+
+mysqli_stmt_bind_param($stmt, 'ii', $startTimestamp, $endTimestamp);
+mysqli_stmt_execute($stmt);
+$result = mysqli_stmt_get_result($stmt);
+$row = $result ? mysqli_fetch_assoc($result) : null;
+
+$high = null;
+$low = null;
+if ($row) {
+  if ($row['high'] !== null) {
+    $high = round((float)$row['high'], 1);
+  }
+  if ($row['low'] !== null) {
+    $low = round((float)$row['low'], 1);
+  }
+}
+
+if ($result) {
+  mysqli_free_result($result);
+}
+mysqli_stmt_close($stmt);
+
+header('Content-Type: application/json');
+echo json_encode([
+  'high' => $high,
+  'low' => $low,
+]);

--- a/frontend/header.php
+++ b/frontend/header.php
@@ -739,7 +739,10 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
       letter-spacing: 0.2em;
       text-transform: uppercase;
       font-weight: 600;
-      color: rgba(226, 232, 240, 0.9);
+      color: rgba(100, 116, 139, 0.95);
+    }
+    html.dark .metric-card .metric-label {
+      color: rgba(148, 163, 184, 0.9);
     }
     .metric-card .metric-value {
       font-size: 2rem;
@@ -777,8 +780,8 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
       border-radius: 2rem;
       border: 1px solid rgba(255, 255, 255, 0.3);
       background:
-        linear-gradient(140deg, rgba(59, 130, 246, 0.32), rgba(14, 165, 233, 0.18)),
-        linear-gradient(160deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.05));
+        linear-gradient(to bottom right, rgba(59, 130, 246, 0.35), rgba(14, 165, 233, 0.15)),
+        linear-gradient(to bottom right, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0.05));
       box-shadow: 0 40px 110px -58px rgba(15, 23, 42, 0.7);
       backdrop-filter: blur(28px);
       overflow: hidden;
@@ -797,8 +800,8 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
     html.dark .dashboard-hero {
       border-color: rgba(148, 163, 184, 0.35);
       background:
-        linear-gradient(140deg, rgba(59, 130, 246, 0.3), rgba(14, 165, 233, 0.2)),
-        linear-gradient(160deg, rgba(15, 23, 42, 0.72), rgba(2, 6, 23, 0.65));
+        linear-gradient(to bottom right, rgba(37, 99, 235, 0.32), rgba(2, 132, 199, 0.2)),
+        linear-gradient(to bottom right, rgba(15, 23, 42, 0.78), rgba(2, 6, 23, 0.68));
       box-shadow: 0 44px 120px -62px rgba(2, 6, 23, 0.85);
     }
     html.dark .dashboard-hero::before {

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -29,6 +29,20 @@ require_once '../dbconn.php';
           </div>
           <ul class="insight-list">
             <li>
+              <span class="label">Today's High</span>
+              <span class="stat-reading">
+                <span data-stat="outTempHigh">--</span>
+                <span class="stat-unit">°C</span>
+              </span>
+            </li>
+            <li>
+              <span class="label">Today's Low</span>
+              <span class="stat-reading">
+                <span data-stat="outTempLow">--</span>
+                <span class="stat-unit">°C</span>
+              </span>
+            </li>
+            <li>
               <span class="label">Rain Today</span>
               <span class="stat-reading">
                 <span data-stat="drain">--</span>
@@ -244,6 +258,8 @@ require_once '../dbconn.php';
       client.onConnectionLost = onConnectionLost;
       client.onMessageArrived = onMessageArrived;
       reconnect();
+      loadDailyExtremes();
+      setInterval(loadDailyExtremes, 5 * 60 * 1000);
     });
 
     function reconnect() {
@@ -304,6 +320,25 @@ require_once '../dbconn.php';
         setStat('drain', dp(obj.dayRain_cm));
         setStat('mrain', dp(obj.monthRain_cm));
       }
+    }
+
+    function loadDailyExtremes() {
+      fetch('backend/today-extremes.php', { cache: 'no-store' })
+        .then(function(response) {
+          if (!response.ok) {
+            throw new Error('Network response was not ok');
+          }
+          return response.json();
+        })
+        .then(function(data) {
+          if (!data) { return; }
+          setStat('outTempHigh', dp(data.high));
+          setStat('outTempLow', dp(data.low));
+        })
+        .catch(function() {
+          setStat('outTempHigh', '--');
+          setStat('outTempLow', '--');
+        });
     }
 
     function setStat(stat, value) {


### PR DESCRIPTION
## Summary
- add daily outside temperature high and low quick stats fed by a lightweight backend endpoint
- refresh hero banner gradient direction and update metric labels to use a grey tone for better hierarchy

## Testing
- php -l frontend/index.php
- php -l frontend/backend/today-extremes.php
- php -l frontend/header.php

------
https://chatgpt.com/codex/tasks/task_e_68cbbbb33d48832e9fa8ccee9b077924