### PR TITLE
Align Highcharts styling with glassmorphism theme

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -85,6 +85,19 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
       --surface-border-dark: rgba(148, 163, 184, 0.25);
       --surface-shadow-light: 0 22px 48px -28px rgba(15, 23, 42, 0.45);
       --surface-shadow-dark: 0 22px 48px -28px rgba(8, 47, 73, 0.55);
+      --chart-surface-light: rgba(255, 255, 255, 0.42);
+      --chart-surface-dark: rgba(15, 23, 42, 0.74);
+      --chart-plot-light: rgba(255, 255, 255, 0.22);
+      --chart-plot-dark: rgba(15, 23, 42, 0.6);
+      --chart-grid-light: rgba(148, 163, 184, 0.28);
+      --chart-grid-dark: rgba(59, 130, 246, 0.35);
+      --chart-tooltip-border-light: rgba(59, 130, 246, 0.45);
+      --chart-tooltip-border-dark: rgba(56, 189, 248, 0.45);
+      --chart-marker-fill-light: rgba(255, 255, 255, 0.85);
+      --chart-marker-fill-dark: rgba(15, 23, 42, 0.85);
+      --chart-area-opacity: 0.45;
+      --chart-palette-light: #1d4ed8, #2563eb, #0ea5e9, #38bdf8, #60a5fa, #a855f7;
+      --chart-palette-dark: #38bdf8, #60a5fa, #22d3ee, #f472b6, #facc15, #f97316;
     }
     body { font-family: 'Inter', sans-serif; }
     h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }

--- a/frontend/js/chart-theme.js
+++ b/frontend/js/chart-theme.js
@@ -1,17 +1,121 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const fallbackPalette = {
+    light: ['#1d4ed8', '#2563eb', '#0ea5e9', '#38bdf8', '#60a5fa', '#a855f7'],
+    dark: ['#38bdf8', '#60a5fa', '#22d3ee', '#f472b6', '#facc15', '#f97316']
+  };
+
+  function getComputedVar(styles, name, fallback) {
+    const value = styles.getPropertyValue(name);
+    if (value && value.trim().length) {
+      return value.trim();
+    }
+    return fallback;
+  }
+
+  function parsePalette(value, fallback) {
+    if (!value) return fallback;
+    const parsed = value
+      .split(',')
+      .map(color => color.trim())
+      .filter(Boolean);
+    return parsed.length ? parsed : fallback;
+  }
+
   function applyChartTheme() {
     if (!window.Highcharts) return;
     const isDark = document.documentElement.classList.contains('dark');
+    const styles = getComputedStyle(document.documentElement);
     const textColor = isDark ? '#f3f4f6' : '#111827';
-    const gridColor = isDark ? '#374151' : '#e5e7eb';
-    const bgColor = isDark ? '#1f2937' : '#ffffff';
+    const gridColor = getComputedVar(styles, isDark ? '--chart-grid-dark' : '--chart-grid-light', isDark ? 'rgba(59, 130, 246, 0.35)' : 'rgba(148, 163, 184, 0.28)');
+    const bgColor = getComputedVar(styles, isDark ? '--chart-surface-dark' : '--chart-surface-light', isDark ? 'rgba(15, 23, 42, 0.74)' : 'rgba(255, 255, 255, 0.42)');
+    const plotBg = getComputedVar(styles, isDark ? '--chart-plot-dark' : '--chart-plot-light', 'transparent');
+    const tooltipBorder = getComputedVar(styles, isDark ? '--chart-tooltip-border-dark' : '--chart-tooltip-border-light', isDark ? 'rgba(56, 189, 248, 0.45)' : 'rgba(59, 130, 246, 0.45)');
+    const markerFill = getComputedVar(styles, isDark ? '--chart-marker-fill-dark' : '--chart-marker-fill-light', isDark ? 'rgba(15, 23, 42, 0.85)' : 'rgba(255, 255, 255, 0.85)');
+    const areaOpacity = parseFloat(getComputedVar(styles, '--chart-area-opacity', '0.45')) || 0.45;
+    const paletteVars = getComputedVar(styles, isDark ? '--chart-palette-dark' : '--chart-palette-light', '');
+    const colors = parsePalette(paletteVars, isDark ? fallbackPalette.dark : fallbackPalette.light);
+
     const opts = {
-      chart: { backgroundColor: bgColor, style: { color: textColor } },
-      title: { style: { color: textColor } },
-      xAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor },
-      yAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor, title: { style: { color: textColor } } },
-      legend: { itemStyle: { color: textColor } }
+      colors,
+      chart: {
+        backgroundColor: bgColor,
+        plotBackgroundColor: plotBg,
+        plotBorderColor: gridColor,
+        style: { color: textColor, fontFamily: 'Inter, sans-serif' }
+      },
+      title: { style: { color: textColor, fontWeight: '700', letterSpacing: '0.02em' } },
+      subtitle: { style: { color: textColor } },
+      xAxis: {
+        labels: { style: { color: textColor } },
+        lineColor: gridColor,
+        tickColor: gridColor,
+        gridLineColor: gridColor,
+        crosshair: { color: tooltipBorder, dashStyle: 'ShortDot' }
+      },
+      yAxis: {
+        labels: { style: { color: textColor } },
+        lineColor: gridColor,
+        tickColor: gridColor,
+        gridLineColor: gridColor,
+        title: { style: { color: textColor } }
+      },
+      legend: {
+        backgroundColor: 'transparent',
+        itemStyle: { color: textColor },
+        itemHoverStyle: { color: tooltipBorder }
+      },
+      tooltip: {
+        backgroundColor: bgColor,
+        borderColor: tooltipBorder,
+        style: { color: textColor, fontFamily: 'Inter, sans-serif' },
+        shared: true,
+        shadow: false,
+        xDateFormat: '%e %b %Y %H:%M'
+      },
+      credits: { style: { color: textColor } },
+      plotOptions: {
+        series: {
+          borderWidth: 0,
+          shadow: false,
+          dataLabels: { color: textColor },
+          marker: {
+            lineWidth: 1.5,
+            lineColor: tooltipBorder,
+            fillColor: markerFill
+          }
+        },
+        areaspline: { fillOpacity: areaOpacity },
+        area: { fillOpacity: areaOpacity },
+        column: {
+          borderRadius: 6,
+          pointPadding: 0.1,
+          groupPadding: 0.08
+        }
+      },
+      rangeSelector: {
+        buttonTheme: {
+          fill: 'transparent',
+          stroke: 'transparent',
+          style: { color: textColor, fontFamily: 'Source Sans Pro, sans-serif' },
+          states: {
+            hover: {
+              fill: plotBg,
+              style: { color: textColor }
+            },
+            select: {
+              fill: tooltipBorder,
+              style: { color: isDark ? '#0f172a' : '#ffffff' }
+            }
+          }
+        },
+        inputStyle: { color: textColor, backgroundColor: bgColor },
+        labelStyle: { color: textColor }
+      },
+      navigator: {
+        maskFill: isDark ? 'rgba(56, 189, 248, 0.2)' : 'rgba(37, 99, 235, 0.2)'
+      }
     };
+
     Highcharts.setOptions(opts);
     if (Highcharts.charts) {
       Highcharts.charts.forEach(chart => {
@@ -22,6 +126,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
   }
+
   applyChartTheme();
   const observer = new MutationObserver(applyChartTheme);
   observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });


### PR DESCRIPTION
## Summary
- expose chart surface, grid, tooltip, and palette values as CSS custom properties that match the site's glassmorphism background.
- update the shared Highcharts theme helper to read the CSS variables, apply translucent backgrounds, and use the brand palette across axes, tooltips, and series.

## Testing
- php -l frontend/header.php

------
https://chatgpt.com/codex/tasks/task_e_68cbc02563d4832e98c944a25961b36f