### PR TITLE
Use diagonal hero gradients for weather themes

### DIFF
--- a/assets/hero-gradient.css
+++ b/assets/hero-gradient.css
@@ -1,54 +1,54 @@
 body[data-weather="clear-night"] {
-  --hero-gradient: linear-gradient(to bottom, #0B1B3B, #1A2A6C);
+  --hero-gradient: linear-gradient(128deg, #0B1B3B 0%, #1A2A6C 100%);
   --hero-foreground: #FFFFFF;
 }
 
 body[data-weather="storm"] {
-  --hero-gradient: linear-gradient(to bottom, #394B59, #101820);
+  --hero-gradient: linear-gradient(128deg, #394B59 0%, #101820 100%);
   --hero-foreground: #FFFFFF;
 }
 
 body[data-weather="heavy-rain"] {
-  --hero-gradient: linear-gradient(to bottom, #4B6B8C, #1F3549);
+  --hero-gradient: linear-gradient(128deg, #4B6B8C 0%, #1F3549 100%);
   --hero-foreground: #FFFFFF;
 }
 
 body[data-weather="rain"] {
-  --hero-gradient: linear-gradient(to bottom, #6D90B9, #2F4F6F);
+  --hero-gradient: linear-gradient(128deg, #6D90B9 0%, #2F4F6F 100%);
   --hero-foreground: #FFFFFF;
 }
 
 body[data-weather="snow"] {
-  --hero-gradient: linear-gradient(to bottom, #E6F2FF, #BFD8F6);
+  --hero-gradient: linear-gradient(128deg, #E6F2FF 0%, #BFD8F6 100%);
   --hero-foreground: #0A0A0A;
 }
 
 body[data-weather="fog"] {
-  --hero-gradient: linear-gradient(to bottom, #D9E2EC, #A3B3C2);
+  --hero-gradient: linear-gradient(128deg, #D9E2EC 0%, #A3B3C2 100%);
   --hero-foreground: #0A0A0A;
 }
 
 body[data-weather="windy"] {
-  --hero-gradient: linear-gradient(to bottom, #B3E5FC, #5EB3E5);
+  --hero-gradient: linear-gradient(128deg, #B3E5FC 0%, #5EB3E5 100%);
   --hero-foreground: #FFFFFF;
 }
 
 body[data-weather="hot"] {
-  --hero-gradient: linear-gradient(to bottom, #FDB36B, #E85D04);
+  --hero-gradient: linear-gradient(128deg, #FDB36B 0%, #E85D04 100%);
   --hero-foreground: #FFFFFF;
 }
 
 body[data-weather="cold"] {
-  --hero-gradient: linear-gradient(to bottom, #B6D0F5, #3A6EA5);
+  --hero-gradient: linear-gradient(128deg, #B6D0F5 0%, #3A6EA5 100%);
   --hero-foreground: #FFFFFF;
 }
 
 body[data-weather="overcast"] {
-  --hero-gradient: linear-gradient(to bottom, #C9D1D9, #8A96A3);
+  --hero-gradient: linear-gradient(128deg, #C9D1D9 0%, #8A96A3 100%);
   --hero-foreground: #0A0A0A;
 }
 
 body[data-weather="stale"] {
-  --hero-gradient: linear-gradient(to bottom, #ECECEC, #BBBBBB);
+  --hero-gradient: linear-gradient(128deg, #ECECEC 0%, #BBBBBB 100%);
   --hero-foreground: #222222;
 }


### PR DESCRIPTION
## Summary
- switch each weather theme gradient to use a 128deg diagonal blend
- preserve existing foreground colors while ensuring the hero no longer renders as stacked color bands

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbc9343c6c832e8cf69e1b1205b9b7