### PR TITLE
Ensure transparent chart styling across frontend

### DIFF
--- a/frontend/dynamic-graph.php
+++ b/frontend/dynamic-graph.php
@@ -276,7 +276,7 @@ function minmaxgraph($gt, $what, $graphrangedata, $graphaveragedata, $gscale, $s
     }
 
     echo "  <div class=\"container-fluid\"><br>
-      <div class=\"card shadow\">
+      <div class=\"chart-frame\">
  <div style=\"height: 75vh;\" id=\"container\" class=\"flex items-center justify-center bg-gray-200 animate-pulse\">Loading graph...</div></div></div>
 <script type=\"text/javascript\">
  document.addEventListener('DOMContentLoaded', function () {
@@ -288,6 +288,10 @@ function minmaxgraph($gt, $what, $graphrangedata, $graphaveragedata, $gscale, $s
  Highcharts.chart('container', {
   chart: {
       zoomType: 'xy',
+      backgroundColor: 'transparent',
+      plotBackgroundColor: 'transparent',
+      plotBorderWidth: 0,
+      plotShadow: false,
       events: {
          load: function() {
              var container = this.renderTo;
@@ -373,8 +377,9 @@ function minmaxgraph($gt, $what, $graphrangedata, $graphaveragedata, $gscale, $s
      x: 100,
      y: 70,
      floating: true,
-     backgroundColor: Highcharts.defaultOptions.chart.backgroundColor,
-     borderWidth: 1
+     backgroundColor: 'transparent',
+     borderWidth: 0,
+     shadow: false
  },
     series: [{
         name: '$what',
@@ -428,7 +433,7 @@ function avgrangegraph($what, $graphrangedata, $graphaveragedata, $gscale, $scal
     }
 
     echo "  <div class=\"container-fluid\"><br>
-      <div class=\"card shadow\">
+      <div class=\"chart-frame\">
  <div style=\"height: 75vh;\" id=\"container\" class=\"flex items-center justify-center bg-gray-200 animate-pulse\">Loading graph...</div></div></div>
 <script type=\"text/javascript\">
  document.addEventListener('DOMContentLoaded', function () {
@@ -439,6 +444,10 @@ function avgrangegraph($what, $graphrangedata, $graphaveragedata, $gscale, $scal
  Highcharts.chart('container', {
   chart: {
       zoomType: 'xy',
+      backgroundColor: 'transparent',
+      plotBackgroundColor: 'transparent',
+      plotBorderWidth: 0,
+      plotShadow: false,
       events: {
          load: function() {
              var container = this.renderTo;
@@ -506,8 +515,9 @@ function avgrangegraph($what, $graphrangedata, $graphaveragedata, $gscale, $scal
      x: 100,
      y: 70,
      floating: true,
-     backgroundColor: Highcharts.defaultOptions.chart.backgroundColor,
-     borderWidth: 1
+     backgroundColor: 'transparent',
+     borderWidth: 0,
+     shadow: false
  },
     series: [{
         name: '$what',
@@ -557,14 +567,18 @@ function standardgraph($gt, $what, $graphdata, $gscale, $scale, $xmin = null, $x
     }
     echo "
     <div class=\"container-fluid\"><br>
-      <div class=\"card shadow\"><div class=\"card-body\">
- <div style=\"height: 75vh;\" id=\"container\" class=\"flex items-center justify-center bg-gray-200 animate-pulse\">Loading graph...</div></div></div></div>
+      <div class=\"chart-frame\">
+ <div style=\"height: 75vh;\" id=\"container\" class=\"flex items-center justify-center bg-gray-200 animate-pulse\">Loading graph...</div></div></div>
  <script type='text/javascript'>
  document.addEventListener('DOMContentLoaded', function () {
  Highcharts.chart('container', {
      chart: {
          type: '$gt',
          zoomType: 'xy',
+         backgroundColor: 'transparent',
+         plotBackgroundColor: 'transparent',
+         plotBorderWidth: 0,
+         plotShadow: false,
          events: {
             load: function() {
                 var container = this.renderTo;

--- a/frontend/extremes.php
+++ b/frontend/extremes.php
@@ -113,7 +113,13 @@ require_once '../dbconn.php';
 document.addEventListener('DOMContentLoaded', function() {
   function renderChart(container, title, data) {
     Highcharts.chart(container, {
-      chart: { type: 'column' },
+      chart: {
+        type: 'column',
+        backgroundColor: 'transparent',
+        plotBackgroundColor: 'transparent',
+        plotBorderWidth: 0,
+        plotShadow: false
+      },
       title: { text: title },
       xAxis: { categories: ['Temp Out', 'Temp In', 'Humidity In', 'Humidity Out', 'Pressure', 'Rain'] },
 

--- a/frontend/header.php
+++ b/frontend/header.php
@@ -109,6 +109,31 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
     body { font-family: 'Inter', sans-serif; }
     h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
     button, .highlight { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
+    .chart-frame {
+      background: transparent;
+      border: none;
+      box-shadow: none;
+      padding: 1rem;
+    }
+    .chart-frame .highcharts-container,
+    .chart-frame .highcharts-root,
+    .chart-frame .highcharts-background,
+    .chart-frame .highcharts-plot-background {
+      background: transparent !important;
+      fill: transparent !important;
+    }
+    .chart-frame .highcharts-plot-border,
+    .chart-frame .highcharts-plot-border-line {
+      stroke: transparent !important;
+    }
+    .highcharts-background,
+    .highcharts-plot-background {
+      fill: transparent !important;
+    }
+    .highcharts-plot-border,
+    .highcharts-plot-border-line {
+      stroke: transparent !important;
+    }
     body.theme-mist {
       min-height: 100vh;
       background: linear-gradient(128deg, #020617 0%, #0f172a 35%, #1d4ed8 100%);

--- a/frontend/historical.php
+++ b/frontend/historical.php
@@ -5,7 +5,7 @@ include('header.php');
   <h2 class="text-xl font-bold mb-2">Historical Data Explorer</h2>
   <p>Use the handles on the timeline to choose a start and end date. Tick the boxes to show multiple data sets at once.</p>
 </div>
-<div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4 mb-4">
+<div class="chart-frame mb-4">
 
   <div class="mb-2" id="dataset-controls"></div>
 
@@ -98,6 +98,12 @@ include('header.php');
       .then(range => {
         fullRange = range;
         chart = Highcharts.stockChart('history-chart', {
+          chart: {
+            backgroundColor: 'transparent',
+            plotBackgroundColor: 'transparent',
+            plotBorderWidth: 0,
+            plotShadow: false
+          },
           rangeSelector: { selected: 0 },
           navigator: { adaptToUpdatedData: false },
           title: { text: 'Historical Data' },

--- a/frontend/js/chart-theme.js
+++ b/frontend/js/chart-theme.js
@@ -40,7 +40,9 @@ document.addEventListener('DOMContentLoaded', () => {
       chart: {
         backgroundColor: 'transparent',
         plotBackgroundColor: 'transparent',
+        plotBorderWidth: 0,
         plotBorderColor: gridColor,
+        plotShadow: false,
         style: { color: textColor, fontFamily: 'Inter, sans-serif' }
       },
       title: { style: { color: textColor, fontWeight: '700', letterSpacing: '0.02em' } },

--- a/frontend/last-time.php
+++ b/frontend/last-time.php
@@ -72,7 +72,7 @@ document.getElementById('what').value = '<?php echo $what ? htmlspecialchars($wh
 document.getElementById('month').value = '<?php echo $month ? htmlspecialchars((string)$month, ENT_QUOTES) : ''; ?>';
 </script>
 <?php if ($month && $what) { ?>
-<div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4">
+<div class="chart-frame">
   <div id="lastTimeChart" class="w-full h-96 animate-pulse bg-gray-200 flex items-center justify-center">Loading...</div>
 </div>
 <script>
@@ -84,6 +84,10 @@ document.addEventListener('DOMContentLoaded', function () {
   Highcharts.chart('lastTimeChart', {
     chart: {
       type: 'area',
+      backgroundColor: 'transparent',
+      plotBackgroundColor: 'transparent',
+      plotBorderWidth: 0,
+      plotShadow: false,
       events: {
         load: function () {
           var container = this.renderTo;

--- a/frontend/metric-graph.php
+++ b/frontend/metric-graph.php
@@ -27,10 +27,10 @@
  if(isset($_GET['FULL'])) {
  include ('header.php');
  echo "<a class=\"inline-block bg-blue-500 text-white px-4 py-2 rounded\" href=\"index.php?item=$item#graph\">Back</a>
-  <div id=\"largecontainer\" class=\"bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4\" style=\"height: 100%; min-width: 100%\"></div>";
+  <div id=\"largecontainer\" class=\"chart-frame\" style=\"height: 100%; min-width: 100%\"></div>";
  } else {
  echo "<p><a class=\"inline-block bg-blue-500 text-white px-4 py-2 rounded\" href=metric-graph.php?FULL=1&item=$item>Click here to open the graph in a seperate page</a></p><div><hr>
- <div id=\"largecontainer\" class=\"bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4\" style=\"height: 100%;\"></div>
+ <div id=\"largecontainer\" class=\"chart-frame\" style=\"height: 100%;\"></div>
  ";
 }
 
@@ -80,7 +80,11 @@ $SQLCOLDM = "SELECT round(MIN(`archive`.`$item`),1) FROM `weewx`.`archive` WHERE
                     chart: {
                         renderTo: 'largecontainer',
                         type: '<?php echo $gt; ?>',
-                        zoomType: 'x'
+                        zoomType: 'x',
+                        backgroundColor: 'transparent',
+                        plotBackgroundColor: 'transparent',
+                        plotBorderWidth: 0,
+                        plotShadow: false
                     },
                     navigator: {
                         adaptToUpdateTimedData: false,

--- a/frontend/overview-graph.php
+++ b/frontend/overview-graph.php
@@ -79,7 +79,11 @@ if(isset($_GET['FULL'])) {
                         chart = new Highcharts.Chart({
                             chart: {
                                 renderTo: 'container3',
-                                zoomType: 'xy'
+                                zoomType: 'xy',
+                                backgroundColor: 'transparent',
+                                plotBackgroundColor: 'transparent',
+                                plotBorderWidth: 0,
+                                plotShadow: false
                             },
                             title: {
                                 text: ''

--- a/frontend/range-graph.php
+++ b/frontend/range-graph.php
@@ -5,9 +5,9 @@ $gt     = "areasplinerange";
 
 if(isset($_GET['FULL'])) {
  include('header.php');
- echo "<a class=\"inline-block bg-blue-500 text-white px-4 py-2 rounded\" href=\"index.php#graph\">Back</a>\n  <div id=\"container2\" class=\"bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4\" style=\"height: 800px; min-width: 100%\"></div>";
-} else {
-  echo "<a class=\"inline-block bg-blue-500 text-white px-4 py-2 rounded\" href=range-graph.php?FULL=1&itemmm=$itemmm>Click here for Full Screen</a>\n <div id=\"container2\" class=\"bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4\" style=\"height: 800px; min-width: 100%\"></div>\n ";
+ echo "<a class=\"inline-block bg-blue-500 text-white px-4 py-2 rounded\" href=\"index.php#graph\">Back</a>\n  <div id=\"container2\" class=\"chart-frame\" style=\"height: 800px; min-width: 100%\"></div>";
+ } else {
+  echo "<a class=\"inline-block bg-blue-500 text-white px-4 py-2 rounded\" href=range-graph.php?FULL=1&itemmm=$itemmm>Click here for Full Screen</a>\n <div id=\"container2\" class=\"chart-frame\" style=\"height: 800px; min-width: 100%\"></div>\n ";
 }
 ?>
 
@@ -26,7 +26,11 @@ if(isset($_GET['FULL'])) {
                     chart: {
                         renderTo: 'container2',
                         type: '<?php echo $gt; ?>',
-                        zoomType: 'x'
+                        zoomType: 'x',
+                        backgroundColor: 'transparent',
+                        plotBackgroundColor: 'transparent',
+                        plotBorderWidth: 0,
+                        plotShadow: false
                     },
                     navigator: {
                         adaptToUpdatedData: false,

--- a/frontend/seasonal.php
+++ b/frontend/seasonal.php
@@ -107,7 +107,13 @@
       if (typeSelect.value === 'temp') {
         valueHeader.textContent = getStatLabel() + ' Temp (°C)';
         Highcharts.chart('seasonal-chart', {
-          chart: { type: 'spline' },
+          chart: {
+            type: 'spline',
+            backgroundColor: 'transparent',
+            plotBackgroundColor: 'transparent',
+            plotBorderWidth: 0,
+            plotShadow: false
+          },
           title: { text: getStatLabel() + ' Monthly Temperature' },
           xAxis: { categories: categories },
           yAxis: { title: { text: 'Temperature (°C)' } },
@@ -117,7 +123,13 @@
       } else {
         valueHeader.textContent = 'Total Rain (mm)';
         Highcharts.chart('seasonal-chart', {
-          chart: { type: 'column' },
+          chart: {
+            type: 'column',
+            backgroundColor: 'transparent',
+            plotBackgroundColor: 'transparent',
+            plotBorderWidth: 0,
+            plotShadow: false
+          },
           title: { text: 'Total Monthly Rainfall' },
           xAxis: { categories: categories },
           yAxis: { title: { text: 'Rainfall (mm)' } },

--- a/frontend/windrose.php
+++ b/frontend/windrose.php
@@ -29,7 +29,7 @@
       <input class="btn" type="submit" value="Select Date">
     </form>
   </div>
-  <div class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow rounded p-4 mb-3">
+  <div class="chart-frame mb-3">
     <div id="container2"></div>
   </div>
 <?php
@@ -97,7 +97,11 @@ document.addEventListener('DOMContentLoaded', function () {
   Highcharts.chart('container2', {
     chart: {
       polar: true,
-      type: 'column'
+      type: 'column',
+      backgroundColor: 'transparent',
+      plotBackgroundColor: 'transparent',
+      plotBorderWidth: 0,
+      plotShadow: false
     },
     title: {
       text: 'Wind rose for st Albans'


### PR DESCRIPTION
## Summary
- add a reusable `chart-frame` wrapper and supporting CSS so chart containers render without borders, shadows, or opaque fills
- update the dynamic graph view and every other Highcharts page to use the new container and explicit transparent chart options
- extend the shared Highcharts theme to clear plot borders and shadows for consistent transparency

## Testing
- php -l frontend/dynamic-graph.php
- php -l frontend/extremes.php
- php -l frontend/historical.php
- php -l frontend/last-time.php
- php -l frontend/metric-graph.php
- php -l frontend/overview-graph.php
- php -l frontend/range-graph.php
- php -l frontend/seasonal.php
- php -l frontend/windrose.php

------
https://chatgpt.com/codex/tasks/task_e_68cbcb5cba60832e9cf7a55805bdcea0