### PR TITLE
Fix hero quick stats responsiveness on mobile

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -982,6 +982,8 @@ $rainTotal = round($row['rainTotal'] * 10, 1);
       color: var(--hero-ink-strong);
     }
     .hero-stats-grid {
+      grid-column: span 12 / span 12;
+      min-width: 0;
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
       gap: 1rem;


### PR DESCRIPTION
## Summary
- ensure the hero quick stats grid spans the full width on small screens
- prevent overflow by allowing the quick stats container to shrink within the hero grid

## Testing
- php -l frontend/header.php

------
https://chatgpt.com/codex/tasks/task_e_68cbd8253038832ea55c6c0490a87a75