### PR TITLE
Adjust hero quick stats alignment

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -1023,7 +1023,7 @@ CSS;
       gap: 1.3rem;
       max-width: 700px;
     }
-    @media (min-width: 1024px) {
+    @media (min-width: 768px) {
       .hero-copy { grid-column: span 7 / span 7; }
       .hero-stats-grid { grid-column: span 5 / span 5; }
     }
@@ -1073,6 +1073,11 @@ CSS;
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
       gap: 1rem;
+    }
+    .hero-stats-grid > .hero-quick-stats:only-child {
+      align-self: start;
+      justify-self: end;
+      width: min(100%, 340px);
     }
     .hero-stat {
       position: relative;


### PR DESCRIPTION
## Summary
- allow the hero copy and quick stats grid to sit side-by-side starting at the tablet breakpoint so the hero section stays compact
- restrict a single quick stats card to align to the right edge of the hero grid for better balance

## Testing
- php -l frontend/header.php

------
https://chatgpt.com/codex/tasks/task_e_68cbddc482b0832ebb7fd8cab27fcb9d