### PR TITLE
Align hero quick stats with hero copy

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -1066,6 +1066,7 @@ CSS;
       display: grid;
       gap: 2.2rem;
       grid-template-columns: repeat(12, minmax(0, 1fr));
+      align-items: start;
     }
     .hero-copy {
       grid-column: span 12 / span 12;
@@ -1124,6 +1125,8 @@ CSS;
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
       gap: 1rem;
+      align-items: start;
+      align-content: start;
     }
     .hero-stats-grid > .hero-quick-stats:only-child {
       align-self: start;


### PR DESCRIPTION
## Summary
- ensure the hero grid aligns its children from the top so the quick stats panel sits level with the hero copy
- make the quick stats grid align its content to the start to avoid vertical drift on larger screens

## Testing
- php -l frontend/header.php

------
https://chatgpt.com/codex/tasks/task_e_68cbdfea2da0832e95ff6a971b5e6c28