### PR TITLE
Enhance sidebar select button styling

### DIFF
--- a/frontend/graph-selector.php
+++ b/frontend/graph-selector.php
@@ -43,7 +43,12 @@ $type = $_GET['TYPE'] ?? '';
       <option value="all">ALL</option>
     </select>
   </div>
-  <button type="submit" class="w-full rounded border border-green-700 px-3 py-2 text-sm font-semibold text-green-700 hover:bg-green-700 hover:text-white">Select</button>
+  <button
+    type="submit"
+    class="w-full inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition duration-150 ease-in-out hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+  >
+    Select
+  </button>
 </form>
 <script>
 const vala = "<?php echo htmlspecialchars($what, ENT_QUOTES); ?>";


### PR DESCRIPTION
## Summary
- restyle the sidebar select button to use the site's blue accent color
- add hover, focus, and shadow treatments for better visibility and alignment with existing design patterns

## Testing
- php -l frontend/graph-selector.php

------
https://chatgpt.com/codex/tasks/task_e_68cbe20f28bc832e865aa64a8e60db19