### PR TITLE
Adjust hero heading size

### DIFF
--- a/frontend/index.php
+++ b/frontend/index.php
@@ -10,7 +10,7 @@ require_once '../dbconn.php';
     <div class="hero-grid">
       <div class="hero-copy">
         <span class="hero-chip">Live Weather Dashboard</span>
-        <h1 class="text-2xl md:text-2xl font-bold drop-shadow-sm">Weather Intelligence for Wheathampstead</h1>
+        <h1 class="text-xl md:text-xl font-bold drop-shadow-sm">Weather Intelligence for Wheathampstead</h1>
         <p class="text-sm md:text-base">Synthesised telemetry from the garden station keeps temperature, moisture and wind trends within one glass surface so you can act quickly.</p>
         <div class="status-card status-card-hero status-disconnected" data-status-container role="status" aria-live="polite" aria-label="Connection status: disconnected">
           <span class="status-dot" data-status-dot aria-hidden="true"></span>


### PR DESCRIPTION
## Summary
- reduce the hero banner heading size so the full tagline stays on one line

## Testing
- php -l frontend/index.php

------
https://chatgpt.com/codex/tasks/task_e_68cbece05970832ea2680860ba899caf