### PR TITLE
Enhance metric tiles with richer color

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -981,6 +981,12 @@ CSS;
       display: flex;
       align-items: baseline;
       gap: 0.3rem;
+      color: rgba(15, 23, 42, 0.92);
+      text-shadow: 0 6px 22px rgba(255, 255, 255, 0.55);
+    }
+    html.dark .metric-card .metric-value {
+      color: rgba(248, 250, 252, 0.96);
+      text-shadow: none;
     }
     .metric-card .metric-value .stat-unit {
       font-size: 0.9rem;


### PR DESCRIPTION
## Summary
- restore a neutral light-mode color for metric values to keep them readable against saturated accent backgrounds
- add a dark-mode override so values remain luminous without the added highlight shadow

## Testing
- php -l frontend/header.php

------
https://chatgpt.com/codex/tasks/task_e_68cd7ff56d48832ea0dc41691220f673