### PR TITLE
Make hero stats grid auto-fit and position Temperature Gauge next to Quick Stats

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -1122,7 +1122,7 @@ CSS;
         align-items: stretch;
       }
     }
-    @media (min-width: 1280px) {
+    @media (min-width: 1024px) {
       .hero-grid {
         grid-template-columns: minmax(0, 1fr) minmax(520px, 1fr);
       }
@@ -1178,7 +1178,7 @@ CSS;
     .hero-stats-grid {
       min-width: 0;
       display: grid;
-      grid-template-columns: minmax(0, 1fr);
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       gap: 0.75rem;
       align-items: start;
       align-content: start;

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -21,33 +21,6 @@ require_once '../dbconn.php';
         </div>
       </div>
       <div class="hero-stats-grid">
-        <div class="insight-card hero-temp-gauge">
-          <div class="flex items-baseline justify-between">
-            <span class="text-xs uppercase tracking-[0.3em] text-slate-600 dark:text-slate-300">Temperature Gauge</span>
-            <i class="fas fa-temperature-high text-slate-400 dark:text-slate-500"></i>
-          </div>
-          <div class="temp-gauge">
-            <div class="temp-gauge-track" data-temp-gauge role="meter" aria-valuemin="0" aria-valuemax="0" aria-valuenow="0" aria-label="Temperature gauge">
-              <div class="temp-gauge-range"></div>
-              <div class="temp-gauge-marker is-hidden" data-temp-marker>
-                <span class="temp-gauge-value">
-                  <span data-stat="OutTemp">--</span><span class="stat-unit">°C</span>
-                </span>
-              </div>
-            </div>
-            <div class="temp-gauge-labels">
-              <span class="temp-gauge-label">
-                <span data-stat="outTempLow">--</span><span class="stat-unit">°C</span>
-                <span class="temp-gauge-caption">Low</span>
-              </span>
-              <span class="temp-gauge-label">
-                <span data-stat="outTempHigh">--</span><span class="stat-unit">°C</span>
-                <span class="temp-gauge-caption">High</span>
-              </span>
-            </div>
-            <p class="temp-gauge-meta">Current temperature positioned between today's low and high.</p>
-          </div>
-        </div>
         <div class="insight-card hero-quick-stats">
           <div class="flex items-baseline justify-between">
             <span class="text-xs uppercase tracking-[0.3em] text-slate-600 dark:text-slate-300">Quick Stats</span>
@@ -92,6 +65,33 @@ require_once '../dbconn.php';
               </span>
             </li>
           </ul>
+        </div>
+        <div class="insight-card hero-temp-gauge">
+          <div class="flex items-baseline justify-between">
+            <span class="text-xs uppercase tracking-[0.3em] text-slate-600 dark:text-slate-300">Temperature Gauge</span>
+            <i class="fas fa-temperature-high text-slate-400 dark:text-slate-500"></i>
+          </div>
+          <div class="temp-gauge">
+            <div class="temp-gauge-track" data-temp-gauge role="meter" aria-valuemin="0" aria-valuemax="0" aria-valuenow="0" aria-label="Temperature gauge">
+              <div class="temp-gauge-range"></div>
+              <div class="temp-gauge-marker is-hidden" data-temp-marker>
+                <span class="temp-gauge-value">
+                  <span data-stat="OutTemp">--</span><span class="stat-unit">°C</span>
+                </span>
+              </div>
+            </div>
+            <div class="temp-gauge-labels">
+              <span class="temp-gauge-label">
+                <span data-stat="outTempLow">--</span><span class="stat-unit">°C</span>
+                <span class="temp-gauge-caption">Low</span>
+              </span>
+              <span class="temp-gauge-label">
+                <span data-stat="outTempHigh">--</span><span class="stat-unit">°C</span>
+                <span class="temp-gauge-caption">High</span>
+              </span>
+            </div>
+            <p class="temp-gauge-meta">Current temperature positioned between today's low and high.</p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Ensure the hero stat cards flow into columns when there is enough horizontal space so the Temperature Gauge can appear alongside Quick Stats at common desktop widths.
- Improve responsiveness of the hero stats area so cards wrap into multiple columns gracefully instead of forcing a single column.

### Description
- Lowered the large-viewport hero layout breakpoint to `@media (min-width: 1024px)` so the hero grid switches to a two-column layout earlier. 
- Changed `.hero-stats-grid` to `grid-template-columns: repeat(auto-fit, minmax(220px, 1fr))` to let stat cards auto-fit into columns when space allows. 
- Moved the Temperature Gauge markup in `frontend/index.php` so it sits next to the Quick Stats card when the grid forms columns.

### Testing
- Ran `php -l frontend/header.php` to confirm PHP/CSS block syntax and it succeeded. 
- Launched the local PHP server and captured a Playwright screenshot of `/index.php` at desktop viewport to validate the layout change, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69809dd91038832e8d1d6440427f0c80)