### PR TITLE
Fix temperature gauge helper text contrast

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -1294,7 +1294,7 @@ CSS;
     }
     .hero-temp-gauge .temp-gauge-meta {
       font-size: 0.72rem;
-      color: rgba(226, 232, 240, 0.72);
+      color: #475569;
     }
     .dashboard-hero [data-stat],
     .dashboard-hero .stat-reading,
@@ -1396,6 +1396,9 @@ CSS;
       background: rgba(15, 23, 42, 0.72);
       border-color: rgba(148, 163, 184, 0.32);
       box-shadow: 0 40px 96px -54px rgba(2, 6, 23, 0.85);
+    }
+    html.dark .hero-temp-gauge .temp-gauge-meta {
+      color: rgba(226, 232, 240, 0.78);
     }
     .insight-list {
       display: grid;


### PR DESCRIPTION
### Motivation
- The temperature gauge helper text in the hero card was effectively unreadable due to a near-white color on a white background, so the contrast needed improving for light-theme cards and preserved for dark mode.

### Description
- Changed the helper text color for `.hero-temp-gauge .temp-gauge-meta` to a darker value (`#475569`) in `frontend/header.php` to improve readability on light cards.
- Added a dark-mode override `html.dark .hero-temp-gauge .temp-gauge-meta { color: rgba(226, 232, 240, 0.78); }` so the helper text remains visible in dark theme.

### Testing
- Ran `php -l frontend/header.php` to validate PHP/CSS embedding syntax and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981b5afc1bc832eaf715b4be8637604)