### PR TITLE
Fix temperature gauge label contrast

### DIFF
--- a/frontend/header.php
+++ b/frontend/header.php
@@ -1279,7 +1279,7 @@ CSS;
       justify-content: space-between;
       gap: 1rem;
       font-size: 0.75rem;
-      color: rgba(241, 245, 249, 0.85);
+      color: #1f2937;
     }
     .hero-temp-gauge .temp-gauge-label {
       display: inline-flex;
@@ -1290,7 +1290,7 @@ CSS;
       font-size: 0.6rem;
       letter-spacing: 0.14em;
       text-transform: uppercase;
-      color: rgba(241, 245, 249, 0.65);
+      color: #475569;
     }
     .hero-temp-gauge .temp-gauge-meta {
       font-size: 0.72rem;
@@ -1399,6 +1399,12 @@ CSS;
     }
     html.dark .hero-temp-gauge .temp-gauge-meta {
       color: rgba(226, 232, 240, 0.78);
+    }
+    html.dark .hero-temp-gauge .temp-gauge-labels {
+      color: rgba(241, 245, 249, 0.85);
+    }
+    html.dark .hero-temp-gauge .temp-gauge-caption {
+      color: rgba(241, 245, 249, 0.65);
     }
     .insight-list {
       display: grid;


### PR DESCRIPTION
### Motivation
- The low/high text in the temperature gauge was unreadable on light cards due to low contrast (white-on-white), so label and caption colors needed adjustment.
- The appearance in dark mode must remain legible and preserve the lighter palette where appropriate.

### Description
- Changed the temperature gauge label color by updating `.hero-temp-gauge .temp-gauge-labels` to `#1f2937` in `frontend/header.php` for improved contrast on light cards.
- Changed the caption color by updating `.hero-temp-gauge .temp-gauge-caption` to `#475569` and added `html.dark` overrides to retain the original lighter colors in dark mode.

### Testing
- Ran `php -l frontend/header.php` and it reported no syntax errors.
- Started a local dev server and ran an automated Playwright script to render `index.php` and capture a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69835ca2e1a4832eb3cdc844c9d3d7f6)